### PR TITLE
chore: remove unused int conversion error mappings

### DIFF
--- a/jwt/src/error.rs
+++ b/jwt/src/error.rs
@@ -35,12 +35,6 @@ pub enum RustyJwtError {
     /// Json error
     #[error(transparent)]
     JsonError(#[from] serde_json::Error),
-    /// Number conversion error
-    #[error(transparent)]
-    NumberError(#[from] core::num::TryFromIntError),
-    /// Number parsing error
-    #[error(transparent)]
-    ParseIntError(#[from] core::num::ParseIntError),
     /// Invalid JSON Patch supplied according to RFC 6902
     #[error("Invalid JSON Patch according to RFC 6902 because {0}")]
     InvalidJsonPath(serde_json::Error),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
