### PR TITLE
fix: change dpop access token 'cnf'

### DIFF
--- a/acme/src/identity.rs
+++ b/acme/src/identity.rs
@@ -185,7 +185,7 @@ AiAVcCmqcVr3MXYNsIa/gnzYlF2/CSGNDD27ke1sLVUo9w==
         let cert_der = pem::parse(CERT).unwrap();
         let spki = cert_der.contents().extract_public_key().unwrap();
         assert_eq!(
-            hex::encode(&spki),
+            hex::encode(spki),
             "fb28fd0ebb4297dbb8e7b9ce38c56d9f212e63a43151c8b33408080d4ec46f18"
         );
     }

--- a/cli/src/access_verify.rs
+++ b/cli/src/access_verify.rs
@@ -40,6 +40,9 @@ pub struct AccessVerify {
     /// e.g. 'SHA-256'
     #[arg(short = 'a', long)]
     hash_algorithm: HashAlgorithm,
+    /// Thumbprint of the dpop proof JWK
+    #[arg(long)]
+    kid: String,
     /// path to file with wire-server's signature public key in PEM format
     #[arg(short = 'k', long)]
     key: PathBuf,
@@ -65,6 +68,7 @@ impl AccessVerify {
             self.max_expiry,
             issuer,
             backend_pk,
+            self.kid,
             self.hash_algorithm,
         );
 

--- a/e2e-identity/README.md
+++ b/e2e-identity/README.md
@@ -11,14 +11,14 @@ sequenceDiagram
     acme-server->>-wire-client: 201
     wire-client->>+acme-server: 🔒 POST /acme/wire/new-order
     acme-server->>-wire-client: 201
-    wire-client->>+acme-server: 🔒 POST /acme/wire/authz/VZ9OvDd8uCSXMXjXVMfQg63TLUnxGZKk
+    wire-client->>+acme-server: 🔒 POST /acme/wire/authz/VRaT4cBr1eYvRHzU2nXAyT2pUgzUc9ES
     acme-server->>-wire-client: 200
     wire-client->>+wire-server:  GET /clients/token/nonce
     wire-server->>-wire-client: 200
     wire-client->>wire-client: create DPoP token
-    wire-client->>+wire-server:  POST /clients/a661e79735dc890f/access-token
+    wire-client->>+wire-server:  POST /clients/ef6a91a91d3337a/access-token
     wire-server->>-wire-client: 200
-    wire-client->>+acme-server: 🔒 POST /acme/wire/challenge/VZ9OvDd8uCSXMXjXVMfQg63TLUnxGZKk/x0gGlwzcz1VJWjgD9dM5RIuoSsLU4yva
+    wire-client->>+acme-server: 🔒 POST /acme/wire/challenge/VRaT4cBr1eYvRHzU2nXAyT2pUgzUc9ES/vrVPmwGhchmsuKJffwy0NASsR643ivxB
     acme-server->>-wire-client: 200
     wire-client->>wire-client: OAUTH authorization request
     wire-client->>+IdP:  GET /dex/auth
@@ -26,19 +26,19 @@ sequenceDiagram
     wire-client->>wire-client: OAUTH authorization code
     wire-client->>+IdP:  POST /dex/token
     IdP->>-wire-client: 200
-    wire-client->>+acme-server: 🔒 POST /acme/wire/challenge/VZ9OvDd8uCSXMXjXVMfQg63TLUnxGZKk/Zaa3kx1T7ThIuYBI4KiS4dmBWetKeXNW
+    wire-client->>+acme-server: 🔒 POST /acme/wire/challenge/VRaT4cBr1eYvRHzU2nXAyT2pUgzUc9ES/n5FFoVwi6IonK80GtLFgpG18ZoKEXoqQ
     acme-server->>-wire-client: 200
-    wire-client->>+acme-server: 🔒 POST /acme/wire/order/D71zUASw1bMHdxcv5z7ZEZPpiImVQo8I
+    wire-client->>+acme-server: 🔒 POST /acme/wire/order/NyuMpBEdChjI5wo4EJEFQOjvb63X68NZ
     acme-server->>-wire-client: 200
-    wire-client->>+acme-server: 🔒 POST /acme/wire/order/D71zUASw1bMHdxcv5z7ZEZPpiImVQo8I/finalize
+    wire-client->>+acme-server: 🔒 POST /acme/wire/order/NyuMpBEdChjI5wo4EJEFQOjvb63X68NZ/finalize
     acme-server->>-wire-client: 200
-    wire-client->>+acme-server: 🔒 POST /acme/wire/certificate/MPd3TpyTezfB7zED0ZBo2HPwCrCDDhHT
+    wire-client->>+acme-server: 🔒 POST /acme/wire/certificate/DHrQ0c6czMSXpJlF36wt0PptFHMLvmQW
     acme-server->>-wire-client: 200
 ```
 ### Initial setup with ACME server
 #### 1. fetch acme directory for hyperlinks
 ```http request
-GET https://stepca:33067/acme/wire/directory
+GET https://stepca:32787/acme/wire/directory
                         /acme/{acme-provisioner}/directory
 ```
 #### 2. get the ACME directory with links for newNonce, newAccount & newOrder
@@ -48,37 +48,37 @@ content-type: application/json
 ```
 ```json
 {
-  "newNonce": "https://stepca:33067/acme/wire/new-nonce",
-  "newAccount": "https://stepca:33067/acme/wire/new-account",
-  "newOrder": "https://stepca:33067/acme/wire/new-order"
+  "newNonce": "https://stepca:32787/acme/wire/new-nonce",
+  "newAccount": "https://stepca:32787/acme/wire/new-account",
+  "newOrder": "https://stepca:32787/acme/wire/new-order"
 }
 ```
 #### 3. fetch a new nonce for the very first request
 ```http request
-HEAD https://stepca:33067/acme/wire/new-nonce
+HEAD https://stepca:32787/acme/wire/new-nonce
                          /acme/{acme-provisioner}/new-nonce
 ```
 #### 4. get a nonce for creating an account
 ```http request
 200
 cache-control: no-store
-link: <https://stepca:33067/acme/wire/directory>;rel="index"
-replay-nonce: MGxJVzQxbm5ydTBCc2tNOFR3VGFiaXhqN29LYU1leDI
+link: <https://stepca:32787/acme/wire/directory>;rel="index"
+replay-nonce: Szk1M1kyalRLVmFQR2swOTI3T3JTam4xM1dHenV1MU0
 ```
 ```text
-MGxJVzQxbm5ydTBCc2tNOFR3VGFiaXhqN29LYU1leDI
+Szk1M1kyalRLVmFQR2swOTI3T3JTam4xM1dHenV1MU0
 ```
 #### 5. create a new account
 ```http request
-POST https://stepca:33067/acme/wire/new-account
+POST https://stepca:32787/acme/wire/new-account
                          /acme/{acme-provisioner}/new-account
 content-type: application/jose+json
 ```
 ```json
 {
-  "protected": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsImp3ayI6eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6IlJrd3QyNnNiejQ0VEZ3RTBMWmhuVGtVOGNnX0tjaVVwRDlYV3kwRXFvMDQifSwibm9uY2UiOiJNR3hKVnpReGJtNXlkVEJDYzJ0Tk9GUjNWR0ZpYVhocU4yOUxZVTFsZURJIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzMwNjcvYWNtZS93aXJlL25ldy1hY2NvdW50In0",
+  "protected": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsImp3ayI6eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6InJXSVBUWWxaTEQwTmpySUVEd2w2NDJUUkg3UnhYYjlnQW5ham5PMGFiaG8ifSwibm9uY2UiOiJTemsxTTFreWFsUkxWbUZRUjJzd09USTNUM0pUYW00eE0xZEhlblYxTVUwIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI3ODcvYWNtZS93aXJlL25ldy1hY2NvdW50In0",
   "payload": "eyJ0ZXJtc09mU2VydmljZUFncmVlZCI6dHJ1ZSwiY29udGFjdCI6WyJ1bmtub3duQGV4YW1wbGUuY29tIl0sIm9ubHlSZXR1cm5FeGlzdGluZyI6ZmFsc2V9",
-  "signature": "H99Fnu2AUPP0SWcCjoisGZqK-R9Y1J3l6tzC9y1I9ULkRtgGcZBBasUedHpx-Q3Vz9fi5WEaLh3I-KvR8K1oDg"
+  "signature": "bR6RTGNg0mSzBpL2_ut8ZNkwqyttaqmDUvyaunyL3ZKryZiEFhJ-I63cLhOPZ7yjm5YthvuVuHXTkNmCOIUkCg"
 }
 ```
 ```json
@@ -95,11 +95,11 @@ content-type: application/jose+json
     "jwk": {
       "crv": "Ed25519",
       "kty": "OKP",
-      "x": "Rkwt26sbz44TFwE0LZhnTkU8cg_KciUpD9XWy0Eqo04"
+      "x": "rWIPTYlZLD0NjrIEDwl642TRH7RxXb9gAnajnO0abho"
     },
-    "nonce": "MGxJVzQxbm5ydTBCc2tNOFR3VGFiaXhqN29LYU1leDI",
+    "nonce": "Szk1M1kyalRLVmFQR2swOTI3T3JTam4xM1dHenV1MU0",
     "typ": "JWT",
-    "url": "https://stepca:33067/acme/wire/new-account"
+    "url": "https://stepca:32787/acme/wire/new-account"
   }
 }
 ```
@@ -108,28 +108,28 @@ content-type: application/jose+json
 201
 cache-control: no-store
 content-type: application/json
-link: <https://stepca:33067/acme/wire/directory>;rel="index"
-location: https://stepca:33067/acme/wire/account/3f8P2A33xAMTUVnNLJTZeHTCjw08Wxu6
-replay-nonce: OWJSeWNDSUJ1UDc3WEJMcGdtdmx2S1FkRzNJUVlMamI
+link: <https://stepca:32787/acme/wire/directory>;rel="index"
+location: https://stepca:32787/acme/wire/account/IYFNc4A0aeSpHOVaqOL366OoVNBPUs1f
+replay-nonce: Wm1PaE1haEI3VXJrdTlvMzlzSmI1WVBudjhtT1dSVEE
 ```
 ```json
 {
   "status": "valid",
-  "orders": "https://stepca:33067/acme/wire/account/3f8P2A33xAMTUVnNLJTZeHTCjw08Wxu6/orders"
+  "orders": "https://stepca:32787/acme/wire/account/IYFNc4A0aeSpHOVaqOL366OoVNBPUs1f/orders"
 }
 ```
 ### Request a certificate with relevant identifiers
 #### 7. create a new order
 ```http request
-POST https://stepca:33067/acme/wire/new-order
+POST https://stepca:32787/acme/wire/new-order
                          /acme/{acme-provisioner}/new-order
 content-type: application/jose+json
 ```
 ```json
 {
-  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMzMDY3L2FjbWUvd2lyZS9hY2NvdW50LzNmOFAyQTMzeEFNVFVWbk5MSlRaZUhUQ2p3MDhXeHU2IiwidHlwIjoiSldUIiwibm9uY2UiOiJPV0pTZVdORFNVSjFVRGMzV0VKTWNHZHRkbXgyUzFGa1J6TkpVVmxNYW1JIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzMwNjcvYWNtZS93aXJlL25ldy1vcmRlciJ9",
-  "payload": "eyJpZGVudGlmaWVycyI6W3sidHlwZSI6IndpcmVhcHAtaWQiLCJ2YWx1ZSI6IntcIm5hbWVcIjpcIkFsaWNlIFNtaXRoXCIsXCJkb21haW5cIjpcIndpcmUuY29tXCIsXCJjbGllbnQtaWRcIjpcImltOndpcmVhcHA9TUdFeE5UQTJNRE5pTW1RNU5EZGhObUptTkdGak5HSmxOVEEyTURZeE5tTS9hNjYxZTc5NzM1ZGM4OTBmQHdpcmUuY29tXCIsXCJoYW5kbGVcIjpcImltOndpcmVhcHA9YWxpY2Vfd2lyZVwifSJ9XSwibm90QmVmb3JlIjoiMjAyMy0wNi0wNlQxMjowODoxOC4zNjI3MzJaIiwibm90QWZ0ZXIiOiIyMDMzLTA2LTAzVDEyOjA4OjE4LjM2MjczMloifQ",
-  "signature": "b1wV3g5sPIF4Re-AyJjcxPGdZ80YEfDyWzm2RImHn-uRo07CliZHy04X4gbMOBckPHBMJMFJz886B30aqYqFCw"
+  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMyNzg3L2FjbWUvd2lyZS9hY2NvdW50L0lZRk5jNEEwYWVTcEhPVmFxT0wzNjZPb1ZOQlBVczFmIiwidHlwIjoiSldUIiwibm9uY2UiOiJXbTFQYUUxaGFFSTNWWEpyZFRsdk16bHpTbUkxV1ZCdWRqaHRUMWRTVkVFIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI3ODcvYWNtZS93aXJlL25ldy1vcmRlciJ9",
+  "payload": "eyJpZGVudGlmaWVycyI6W3sidHlwZSI6IndpcmVhcHAtaWQiLCJ2YWx1ZSI6IntcIm5hbWVcIjpcIkFsaWNlIFNtaXRoXCIsXCJkb21haW5cIjpcIndpcmUuY29tXCIsXCJjbGllbnQtaWRcIjpcImltOndpcmVhcHA9TmpZM05UVmhOR1l6TXpFNE5HRmpNRGd5T0dRNVpUWmhPR00zTnpZeE5USS9lZjZhOTFhOTFkMzMzN2FAd2lyZS5jb21cIixcImhhbmRsZVwiOlwiaW06d2lyZWFwcD1hbGljZV93aXJlXCJ9In1dLCJub3RCZWZvcmUiOiIyMDIzLTA3LTMxVDA5OjI3OjUyLjc1NDYzNloiLCJub3RBZnRlciI6IjIwMzMtMDctMjhUMDk6Mjc6NTIuNzU0NjM2WiJ9",
+  "signature": "ImdJCgVTxzDEMRTUCoNk1lAQi9_5-x6PiT7i5V-tTgbQuKtgDpXAix0pawojE_AcadWjJOkLWPTxC7dp9B_LBA"
 }
 ```
 ```json
@@ -138,18 +138,18 @@ content-type: application/jose+json
     "identifiers": [
       {
         "type": "wireapp-id",
-        "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"im:wireapp=MGExNTA2MDNiMmQ5NDdhNmJmNGFjNGJlNTA2MDYxNmM/a661e79735dc890f@wire.com\",\"handle\":\"im:wireapp=alice_wire\"}"
+        "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"im:wireapp=NjY3NTVhNGYzMzE4NGFjMDgyOGQ5ZTZhOGM3NzYxNTI/ef6a91a91d3337a@wire.com\",\"handle\":\"im:wireapp=alice_wire\"}"
       }
     ],
-    "notAfter": "2033-06-03T12:08:18.362732Z",
-    "notBefore": "2023-06-06T12:08:18.362732Z"
+    "notAfter": "2033-07-28T09:27:52.754636Z",
+    "notBefore": "2023-07-31T09:27:52.754636Z"
   },
   "protected": {
     "alg": "EdDSA",
-    "kid": "https://stepca:33067/acme/wire/account/3f8P2A33xAMTUVnNLJTZeHTCjw08Wxu6",
-    "nonce": "OWJSeWNDSUJ1UDc3WEJMcGdtdmx2S1FkRzNJUVlMamI",
+    "kid": "https://stepca:32787/acme/wire/account/IYFNc4A0aeSpHOVaqOL366OoVNBPUs1f",
+    "nonce": "Wm1PaE1haEI3VXJrdTlvMzlzSmI1WVBudjhtT1dSVEE",
     "typ": "JWT",
-    "url": "https://stepca:33067/acme/wire/new-order"
+    "url": "https://stepca:32787/acme/wire/new-order"
   }
 }
 ```
@@ -158,40 +158,40 @@ content-type: application/jose+json
 201
 cache-control: no-store
 content-type: application/json
-link: <https://stepca:33067/acme/wire/directory>;rel="index"
-location: https://stepca:33067/acme/wire/order/D71zUASw1bMHdxcv5z7ZEZPpiImVQo8I
-replay-nonce: U0VPbFE5N0R0Ujg0dWYwbjJoZVBQNEwwQXdqSUluWXU
+link: <https://stepca:32787/acme/wire/directory>;rel="index"
+location: https://stepca:32787/acme/wire/order/NyuMpBEdChjI5wo4EJEFQOjvb63X68NZ
+replay-nonce: U0NTTUR6aVpMSExTYmFQdHpxa2Viak9EcGZlZnd3ODA
 ```
 ```json
 {
   "status": "pending",
-  "finalize": "https://stepca:33067/acme/wire/order/D71zUASw1bMHdxcv5z7ZEZPpiImVQo8I/finalize",
+  "finalize": "https://stepca:32787/acme/wire/order/NyuMpBEdChjI5wo4EJEFQOjvb63X68NZ/finalize",
   "identifiers": [
     {
       "type": "wireapp-id",
-      "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"im:wireapp=MGExNTA2MDNiMmQ5NDdhNmJmNGFjNGJlNTA2MDYxNmM/a661e79735dc890f@wire.com\",\"handle\":\"im:wireapp=alice_wire\"}"
+      "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"im:wireapp=NjY3NTVhNGYzMzE4NGFjMDgyOGQ5ZTZhOGM3NzYxNTI/ef6a91a91d3337a@wire.com\",\"handle\":\"im:wireapp=alice_wire\"}"
     }
   ],
   "authorizations": [
-    "https://stepca:33067/acme/wire/authz/VZ9OvDd8uCSXMXjXVMfQg63TLUnxGZKk"
+    "https://stepca:32787/acme/wire/authz/VRaT4cBr1eYvRHzU2nXAyT2pUgzUc9ES"
   ],
-  "expires": "2023-06-07T12:08:18Z",
-  "notBefore": "2023-06-06T12:08:18.362732Z",
-  "notAfter": "2033-06-03T12:08:18.362732Z"
+  "expires": "2023-08-01T09:27:52Z",
+  "notBefore": "2023-07-31T09:27:52.754636Z",
+  "notAfter": "2033-07-28T09:27:52.754636Z"
 }
 ```
 ### Display-name and handle already authorized
 #### 9. create authorization and fetch challenges
 ```http request
-POST https://stepca:33067/acme/wire/authz/VZ9OvDd8uCSXMXjXVMfQg63TLUnxGZKk
+POST https://stepca:32787/acme/wire/authz/VRaT4cBr1eYvRHzU2nXAyT2pUgzUc9ES
                          /acme/{acme-provisioner}/authz/{authz-id}
 content-type: application/jose+json
 ```
 ```json
 {
-  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMzMDY3L2FjbWUvd2lyZS9hY2NvdW50LzNmOFAyQTMzeEFNVFVWbk5MSlRaZUhUQ2p3MDhXeHU2IiwidHlwIjoiSldUIiwibm9uY2UiOiJVMFZQYkZFNU4wUjBVamcwZFdZd2JqSm9aVkJRTkV3d1FYZHFTVWx1V1hVIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzMwNjcvYWNtZS93aXJlL2F1dGh6L1ZaOU92RGQ4dUNTWE1YalhWTWZRZzYzVExVbnhHWktrIn0",
+  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMyNzg3L2FjbWUvd2lyZS9hY2NvdW50L0lZRk5jNEEwYWVTcEhPVmFxT0wzNjZPb1ZOQlBVczFmIiwidHlwIjoiSldUIiwibm9uY2UiOiJVME5UVFVSNmFWcE1TRXhUWW1GUWRIcHhhMlZpYWs5RWNHWmxabmQzT0RBIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI3ODcvYWNtZS93aXJlL2F1dGh6L1ZSYVQ0Y0JyMWVZdlJIelUyblhBeVQycFVnelVjOUVTIn0",
   "payload": "",
-  "signature": "5F7__UJvH6_kZBWRrS1GvxH8wS4tf6ROTuPOF_t2UwMm5QUn0l0eqDpqLPQX7Af4F3VTUgGPqw-MX6azukwbBw"
+  "signature": "lN1I0xxiTl7PN89v30zId7FfSL7TJVZ_-P0-Er-IbTw0ozSb4ba4HN1VEeM6P-IPS8VOZGaX4fXlbHXfp28MDw"
 }
 ```
 ```json
@@ -199,10 +199,10 @@ content-type: application/jose+json
   "payload": {},
   "protected": {
     "alg": "EdDSA",
-    "kid": "https://stepca:33067/acme/wire/account/3f8P2A33xAMTUVnNLJTZeHTCjw08Wxu6",
-    "nonce": "U0VPbFE5N0R0Ujg0dWYwbjJoZVBQNEwwQXdqSUluWXU",
+    "kid": "https://stepca:32787/acme/wire/account/IYFNc4A0aeSpHOVaqOL366OoVNBPUs1f",
+    "nonce": "U0NTTUR6aVpMSExTYmFQdHpxa2Viak9EcGZlZnd3ODA",
     "typ": "JWT",
-    "url": "https://stepca:33067/acme/wire/authz/VZ9OvDd8uCSXMXjXVMfQg63TLUnxGZKk"
+    "url": "https://stepca:32787/acme/wire/authz/VRaT4cBr1eYvRHzU2nXAyT2pUgzUc9ES"
   }
 }
 ```
@@ -211,40 +211,40 @@ content-type: application/jose+json
 200
 cache-control: no-store
 content-type: application/json
-link: <https://stepca:33067/acme/wire/directory>;rel="index"
-location: https://stepca:33067/acme/wire/authz/VZ9OvDd8uCSXMXjXVMfQg63TLUnxGZKk
-replay-nonce: NkRXZ1NONjQ1QTBMM3lpeUJ4QklmYWNZUzBtRzkwUGg
+link: <https://stepca:32787/acme/wire/directory>;rel="index"
+location: https://stepca:32787/acme/wire/authz/VRaT4cBr1eYvRHzU2nXAyT2pUgzUc9ES
+replay-nonce: cjlzRXlDWDlDYXBCTXAxRlpkTWdhNkVGdzlidlZkMlo
 ```
 ```json
 {
   "status": "pending",
-  "expires": "2023-06-07T12:08:18Z",
+  "expires": "2023-08-01T09:27:52Z",
   "challenges": [
     {
       "type": "wire-oidc-01",
-      "url": "https://stepca:33067/acme/wire/challenge/VZ9OvDd8uCSXMXjXVMfQg63TLUnxGZKk/Zaa3kx1T7ThIuYBI4KiS4dmBWetKeXNW",
+      "url": "https://stepca:32787/acme/wire/challenge/VRaT4cBr1eYvRHzU2nXAyT2pUgzUc9ES/n5FFoVwi6IonK80GtLFgpG18ZoKEXoqQ",
       "status": "pending",
-      "token": "84ShBugQ6MiMBPEjjLAxAUklhAzKubGS",
-      "target": "http://dex:16070/dex"
+      "token": "PmPL5ifCHeBvoeGTj7idCieaCkONv9Bh",
+      "target": "http://dex:16002/dex"
     },
     {
       "type": "wire-dpop-01",
-      "url": "https://stepca:33067/acme/wire/challenge/VZ9OvDd8uCSXMXjXVMfQg63TLUnxGZKk/x0gGlwzcz1VJWjgD9dM5RIuoSsLU4yva",
+      "url": "https://stepca:32787/acme/wire/challenge/VRaT4cBr1eYvRHzU2nXAyT2pUgzUc9ES/vrVPmwGhchmsuKJffwy0NASsR643ivxB",
       "status": "pending",
-      "token": "84ShBugQ6MiMBPEjjLAxAUklhAzKubGS",
-      "target": "http://wire.com:15602/clients/a661e79735dc890f/access-token"
+      "token": "PmPL5ifCHeBvoeGTj7idCieaCkONv9Bh",
+      "target": "http://wire.com:23176/clients/ef6a91a91d3337a/access-token"
     }
   ],
   "identifier": {
     "type": "wireapp-id",
-    "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"im:wireapp=MGExNTA2MDNiMmQ5NDdhNmJmNGFjNGJlNTA2MDYxNmM/a661e79735dc890f@wire.com\",\"handle\":\"im:wireapp=alice_wire\"}"
+    "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"im:wireapp=NjY3NTVhNGYzMzE4NGFjMDgyOGQ5ZTZhOGM3NzYxNTI/ef6a91a91d3337a@wire.com\",\"handle\":\"im:wireapp=alice_wire\"}"
   }
 }
 ```
 ### Client fetches JWT DPoP access token (with wire-server)
 #### 11. fetch a nonce from wire-server
 ```http request
-GET http://wire.com:15602/clients/token/nonce
+GET http://wire.com:23176/clients/token/nonce
 ```
 #### 12. get wire-server nonce
 ```http request
@@ -252,7 +252,7 @@ GET http://wire.com:15602/clients/token/nonce
 
 ```
 ```text
-TENEdGk0cklldzVGYU1wcHRUS29uSXk2TVJ6NEFWcjE
+ZXgyc0dBWlJQRUxnYW13NWR6RDZHc1dqYzJmZHkzblI
 ```
 #### 13. create client DPoP token
 
@@ -260,22 +260,22 @@ TENEdGk0cklldzVGYU1wcHRUS29uSXk2TVJ6NEFWcjE
 <details>
 <summary><b>Dpop token</b></summary>
 
-See it on [jwt.io](https://jwt.io/#id_token=eyJhbGciOiJFZERTQSIsInR5cCI6ImRwb3Arand0IiwiandrIjp7Imt0eSI6Ik9LUCIsImNydiI6IkVkMjU1MTkiLCJ4IjoiUmt3dDI2c2J6NDRURndFMExaaG5Ua1U4Y2dfS2NpVXBEOVhXeTBFcW8wNCJ9fQ.eyJpYXQiOjE2ODYwNTMyOTgsImV4cCI6MTY4NjA1Njg5OCwibmJmIjoxNjg2MDUzMjkzLCJzdWIiOiJpbTp3aXJlYXBwPU1HRXhOVEEyTUROaU1tUTVORGRoTm1KbU5HRmpOR0psTlRBMk1EWXhObU0vYTY2MWU3OTczNWRjODkwZkB3aXJlLmNvbSIsImp0aSI6IjFjMGQ4Y2UzLTBjNGYtNDZlYi04MmQ5LTNiYjIzMTRmNDdlYyIsIm5vbmNlIjoiVEVORWRHazBja2xsZHpWR1lVMXdjSFJVUzI5dVNYazJUVko2TkVGV2NqRSIsImh0bSI6IlBPU1QiLCJodHUiOiJodHRwOi8vd2lyZS5jb206MTU2MDIvY2xpZW50cy9hNjYxZTc5NzM1ZGM4OTBmL2FjY2Vzcy10b2tlbiIsImNoYWwiOiI4NFNoQnVnUTZNaU1CUEVqakxBeEFVa2xoQXpLdWJHUyJ9.InDqAykzehhyrHTz74wWFx7L0muyJpINwNoNlGgvyC2CsYjBBSZttg1FoMzQp9qVKON84AH1971F3ot64SNCAA)
+See it on [jwt.io](https://jwt.io/#id_token=eyJhbGciOiJFZERTQSIsInR5cCI6ImRwb3Arand0IiwiandrIjp7Imt0eSI6Ik9LUCIsImNydiI6IkVkMjU1MTkiLCJ4IjoicldJUFRZbFpMRDBOanJJRUR3bDY0MlRSSDdSeFhiOWdBbmFqbk8wYWJobyJ9fQ.eyJpYXQiOjE2OTA3OTU2NzIsImV4cCI6MTY5MDc5OTI3MiwibmJmIjoxNjkwNzk1NjY3LCJzdWIiOiJpbTp3aXJlYXBwPU5qWTNOVFZoTkdZek16RTROR0ZqTURneU9HUTVaVFpoT0dNM056WXhOVEkvZWY2YTkxYTkxZDMzMzdhQHdpcmUuY29tIiwianRpIjoiYjdmYzQxNGUtMzc0OS00Mjc2LTg3MzUtZjgzMzU4ZThhMjhmIiwibm9uY2UiOiJaWGd5YzBkQldsSlFSVXhuWVcxM05XUjZSRFpIYzFkcVl6Sm1aSGt6YmxJIiwiaHRtIjoiUE9TVCIsImh0dSI6Imh0dHA6Ly93aXJlLmNvbToyMzE3Ni9jbGllbnRzL2VmNmE5MWE5MWQzMzM3YS9hY2Nlc3MtdG9rZW4iLCJjaGFsIjoiUG1QTDVpZkNIZUJ2b2VHVGo3aWRDaWVhQ2tPTnY5QmgifQ.D8tvYks_Skprd3YLgFHdbHxbhzuPlwI_-clcwfqDCXSLv13iiikNoFmBKhDbNDrf8DHuHfpnIDUjAnowTT91Aw)
 
 Raw:
 ```text
 eyJhbGciOiJFZERTQSIsInR5cCI6ImRwb3Arand0IiwiandrIjp7Imt0eSI6Ik9L
-UCIsImNydiI6IkVkMjU1MTkiLCJ4IjoiUmt3dDI2c2J6NDRURndFMExaaG5Ua1U4
-Y2dfS2NpVXBEOVhXeTBFcW8wNCJ9fQ.eyJpYXQiOjE2ODYwNTMyOTgsImV4cCI6M
-TY4NjA1Njg5OCwibmJmIjoxNjg2MDUzMjkzLCJzdWIiOiJpbTp3aXJlYXBwPU1HR
-XhOVEEyTUROaU1tUTVORGRoTm1KbU5HRmpOR0psTlRBMk1EWXhObU0vYTY2MWU3O
-TczNWRjODkwZkB3aXJlLmNvbSIsImp0aSI6IjFjMGQ4Y2UzLTBjNGYtNDZlYi04M
-mQ5LTNiYjIzMTRmNDdlYyIsIm5vbmNlIjoiVEVORWRHazBja2xsZHpWR1lVMXdjS
-FJVUzI5dVNYazJUVko2TkVGV2NqRSIsImh0bSI6IlBPU1QiLCJodHUiOiJodHRwO
-i8vd2lyZS5jb206MTU2MDIvY2xpZW50cy9hNjYxZTc5NzM1ZGM4OTBmL2FjY2Vzc
-y10b2tlbiIsImNoYWwiOiI4NFNoQnVnUTZNaU1CUEVqakxBeEFVa2xoQXpLdWJHU
-yJ9.InDqAykzehhyrHTz74wWFx7L0muyJpINwNoNlGgvyC2CsYjBBSZttg1FoMzQ
-p9qVKON84AH1971F3ot64SNCAA
+UCIsImNydiI6IkVkMjU1MTkiLCJ4IjoicldJUFRZbFpMRDBOanJJRUR3bDY0MlRS
+SDdSeFhiOWdBbmFqbk8wYWJobyJ9fQ.eyJpYXQiOjE2OTA3OTU2NzIsImV4cCI6M
+TY5MDc5OTI3MiwibmJmIjoxNjkwNzk1NjY3LCJzdWIiOiJpbTp3aXJlYXBwPU5qW
+TNOVFZoTkdZek16RTROR0ZqTURneU9HUTVaVFpoT0dNM056WXhOVEkvZWY2YTkxY
+TkxZDMzMzdhQHdpcmUuY29tIiwianRpIjoiYjdmYzQxNGUtMzc0OS00Mjc2LTg3M
+zUtZjgzMzU4ZThhMjhmIiwibm9uY2UiOiJaWGd5YzBkQldsSlFSVXhuWVcxM05XU
+jZSRFpIYzFkcVl6Sm1aSGt6YmxJIiwiaHRtIjoiUE9TVCIsImh0dSI6Imh0dHA6L
+y93aXJlLmNvbToyMzE3Ni9jbGllbnRzL2VmNmE5MWE5MWQzMzM3YS9hY2Nlc3Mtd
+G9rZW4iLCJjaGFsIjoiUG1QTDVpZkNIZUJ2b2VHVGo3aWRDaWVhQ2tPTnY5Qmgif
+Q.D8tvYks_Skprd3YLgFHdbHxbhzuPlwI_-clcwfqDCXSLv13iiikNoFmBKhDbND
+rf8DHuHfpnIDUjAnowTT91Aw
 ```
 
 Decoded:
@@ -286,7 +286,7 @@ Decoded:
   "jwk": {
     "crv": "Ed25519",
     "kty": "OKP",
-    "x": "Rkwt26sbz44TFwE0LZhnTkU8cg_KciUpD9XWy0Eqo04"
+    "x": "rWIPTYlZLD0NjrIEDwl642TRH7RxXb9gAnajnO0abho"
   },
   "typ": "dpop+jwt"
 }
@@ -294,15 +294,15 @@ Decoded:
 
 ```json
 {
-  "chal": "84ShBugQ6MiMBPEjjLAxAUklhAzKubGS",
-  "exp": 1686056898,
+  "chal": "PmPL5ifCHeBvoeGTj7idCieaCkONv9Bh",
+  "exp": 1690799272,
   "htm": "POST",
-  "htu": "http://wire.com:15602/clients/a661e79735dc890f/access-token",
-  "iat": 1686053298,
-  "jti": "1c0d8ce3-0c4f-46eb-82d9-3bb2314f47ec",
-  "nbf": 1686053293,
-  "nonce": "TENEdGk0cklldzVGYU1wcHRUS29uSXk2TVJ6NEFWcjE",
-  "sub": "im:wireapp=MGExNTA2MDNiMmQ5NDdhNmJmNGFjNGJlNTA2MDYxNmM/a661e79735dc890f@wire.com"
+  "htu": "http://wire.com:23176/clients/ef6a91a91d3337a/access-token",
+  "iat": 1690795672,
+  "jti": "b7fc414e-3749-4276-8735-f83358e8a28f",
+  "nbf": 1690795667,
+  "nonce": "ZXgyc0dBWlJQRUxnYW13NWR6RDZHc1dqYzJmZHkzblI",
+  "sub": "im:wireapp=NjY3NTVhNGYzMzE4NGFjMDgyOGQ5ZTZhOGM3NzYxNTI/ef6a91a91d3337a@wire.com"
 }
 ```
 
@@ -310,10 +310,10 @@ Decoded:
 ✅ Signature Verified with key:
 ```text
 -----BEGIN PRIVATE KEY-----
-MC4CAQAwBQYDK2VwBCIEICaZZfYEGXeuQdASOLfbbqTyz3P0gntXa8NzOl34qNIA
+MC4CAQAwBQYDK2VwBCIEIGZXZOk3T+fsUFBsjUaEjIDk1bJixBqWuZsrY2NnxBMV
 -----END PRIVATE KEY-----
 -----BEGIN PUBLIC KEY-----
-MCowBQYDK2VwAyEARkwt26sbz44TFwE0LZhnTkU8cg/KciUpD9XWy0Eqo04=
+MCowBQYDK2VwAyEArWIPTYlZLD0NjrIEDwl642TRH7RxXb9gAnajnO0abho=
 -----END PUBLIC KEY-----
 ```
 
@@ -322,9 +322,9 @@ MCowBQYDK2VwAyEARkwt26sbz44TFwE0LZhnTkU8cg/KciUpD9XWy0Eqo04=
 
 #### 14. trade client DPoP token for an access token
 ```http request
-POST http://wire.com:15602/clients/a661e79735dc890f/access-token
+POST http://wire.com:23176/clients/ef6a91a91d3337a/access-token
                           /clients/{device-id}/access-token
-dpop: ZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNkltUndiM0FyYW5kMElpd2lhbmRySWpwN0ltdDBlU0k2SWs5TFVDSXNJbU55ZGlJNklrVmtNalUxTVRraUxDSjRJam9pVW10M2RESTJjMko2TkRSVVJuZEZNRXhhYUc1VWExVTRZMmRmUzJOcFZYQkVPVmhYZVRCRmNXOHdOQ0o5ZlEuZXlKcFlYUWlPakUyT0RZd05UTXlPVGdzSW1WNGNDSTZNVFk0TmpBMU5qZzVPQ3dpYm1KbUlqb3hOamcyTURVek1qa3pMQ0p6ZFdJaU9pSnBiVHAzYVhKbFlYQndQVTFIUlhoT1ZFRXlUVVJPYVUxdFVUVk9SR1JvVG0xS2JVNUhSbXBPUjBwc1RsUkJNazFFV1hoT2JVMHZZVFkyTVdVM09UY3pOV1JqT0Rrd1prQjNhWEpsTG1OdmJTSXNJbXAwYVNJNklqRmpNR1E0WTJVekxUQmpOR1l0TkRabFlpMDRNbVE1TFROaVlqSXpNVFJtTkRkbFl5SXNJbTV2Ym1ObElqb2lWRVZPUldSSGF6QmphMnhzWkhwV1IxbFZNWGRqU0ZKVlV6STVkVk5ZYXpKVVZrbzJUa1ZHVjJOcVJTSXNJbWgwYlNJNklsQlBVMVFpTENKb2RIVWlPaUpvZEhSd09pOHZkMmx5WlM1amIyMDZNVFUyTURJdlkyeHBaVzUwY3k5aE5qWXhaVGM1TnpNMVpHTTRPVEJtTDJGalkyVnpjeTEwYjJ0bGJpSXNJbU5vWVd3aU9pSTRORk5vUW5WblVUWk5hVTFDVUVWcWFreEJlRUZWYTJ4b1FYcExkV0pIVXlKOS5JbkRxQXlremVoaHlySFR6NzR3V0Z4N0wwbXV5SnBJTndOb05sR2d2eUMyQ3NZakJCU1p0dGcxRm9NelFwOXFWS09OODRBSDE5NzFGM290NjRTTkNBQQ
+dpop: ZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNkltUndiM0FyYW5kMElpd2lhbmRySWpwN0ltdDBlU0k2SWs5TFVDSXNJbU55ZGlJNklrVmtNalUxTVRraUxDSjRJam9pY2xkSlVGUlpiRnBNUkRCT2FuSkpSVVIzYkRZME1sUlNTRGRTZUZoaU9XZEJibUZxYms4d1lXSm9ieUo5ZlEuZXlKcFlYUWlPakUyT1RBM09UVTJOeklzSW1WNGNDSTZNVFk1TURjNU9USTNNaXdpYm1KbUlqb3hOamt3TnprMU5qWTNMQ0p6ZFdJaU9pSnBiVHAzYVhKbFlYQndQVTVxV1ROT1ZGWm9Ua2RaZWsxNlJUUk9SMFpxVFVSbmVVOUhVVFZhVkZwb1QwZE5NMDU2V1hoT1ZFa3ZaV1kyWVRreFlUa3haRE16TXpkaFFIZHBjbVV1WTI5dElpd2lhblJwSWpvaVlqZG1ZelF4TkdVdE16YzBPUzAwTWpjMkxUZzNNelV0Wmpnek16VTRaVGhoTWpobUlpd2libTl1WTJVaU9pSmFXR2Q1WXpCa1FsZHNTbEZTVlhodVdWY3hNMDVYVWpaU1JGcElZekZrY1ZsNlNtMWFTR3Q2WW14Sklpd2lhSFJ0SWpvaVVFOVRWQ0lzSW1oMGRTSTZJbWgwZEhBNkx5OTNhWEpsTG1OdmJUb3lNekUzTmk5amJHbGxiblJ6TDJWbU5tRTVNV0U1TVdRek16TTNZUzloWTJObGMzTXRkRzlyWlc0aUxDSmphR0ZzSWpvaVVHMVFURFZwWmtOSVpVSjJiMlZIVkdvM2FXUkRhV1ZoUTJ0UFRuWTVRbWdpZlEuRDh0dllrc19Ta3ByZDNZTGdGSGRiSHhiaHp1UGx3SV8tY2xjd2ZxRENYU0x2MTNpaWlrTm9GbUJLaERiTkRyZjhESHVIZnBuSURVakFub3dUVDkxQXc
 ```
 #### 15. get a Dpop access token from wire-server
 ```http request
@@ -334,7 +334,7 @@ dpop: ZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNkltUndiM0FyYW5kMElpd2lhbmRySWpwN0ltdD
 ```json
 {
   "expires_in": 2082008461,
-  "token": "eyJhbGciOiJFZERTQSIsInR5cCI6ImF0K2p3dCIsImp3ayI6eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Im52bnFvTEZPc0xGcEYzbEJDRVhpb0d1NGhuYUYxbENVU3F1T085RkU5MDAifX0.eyJpYXQiOjE2ODYwNTMyOTgsImV4cCI6MTY5MzgyOTI5OCwibmJmIjoxNjg2MDUzMjkzLCJpc3MiOiJodHRwOi8vd2lyZS5jb206MTU2MDIvY2xpZW50cy9hNjYxZTc5NzM1ZGM4OTBmL2FjY2Vzcy10b2tlbiIsInN1YiI6ImltOndpcmVhcHA9TUdFeE5UQTJNRE5pTW1RNU5EZGhObUptTkdGak5HSmxOVEEyTURZeE5tTS9hNjYxZTc5NzM1ZGM4OTBmQHdpcmUuY29tIiwiYXVkIjoiaHR0cDovL3dpcmUuY29tOjE1NjAyL2NsaWVudHMvYTY2MWU3OTczNWRjODkwZi9hY2Nlc3MtdG9rZW4iLCJqdGkiOiI2OThjMDg2MC1jM2E0LTQ2NGEtYmVkMy02NjdmOTViNzYyOTYiLCJub25jZSI6IlRFTkVkR2swY2tsbGR6VkdZVTF3Y0hSVVMyOXVTWGsyVFZKNk5FRldjakUiLCJjaGFsIjoiODRTaEJ1Z1E2TWlNQlBFampMQXhBVWtsaEF6S3ViR1MiLCJjbmYiOnsia2lkIjoiYkZBN08wbnctS3ZzYWxUdVJqTGg5aEUtd2dtQTJKR2E0SnhQbDBxVnpjZyJ9LCJwcm9vZiI6ImV5SmhiR2NpT2lKRlpFUlRRU0lzSW5SNWNDSTZJbVJ3YjNBcmFuZDBJaXdpYW5kcklqcDdJbXQwZVNJNklrOUxVQ0lzSW1OeWRpSTZJa1ZrTWpVMU1Ua2lMQ0o0SWpvaVVtdDNkREkyYzJKNk5EUlVSbmRGTUV4YWFHNVVhMVU0WTJkZlMyTnBWWEJFT1ZoWGVUQkZjVzh3TkNKOWZRLmV5SnBZWFFpT2pFMk9EWXdOVE15T1Rnc0ltVjRjQ0k2TVRZNE5qQTFOamc1T0N3aWJtSm1Jam94TmpnMk1EVXpNamt6TENKemRXSWlPaUpwYlRwM2FYSmxZWEJ3UFUxSFJYaE9WRUV5VFVST2FVMXRVVFZPUkdSb1RtMUtiVTVIUm1wT1IwcHNUbFJCTWsxRVdYaE9iVTB2WVRZMk1XVTNPVGN6TldSak9Ea3daa0IzYVhKbExtTnZiU0lzSW1wMGFTSTZJakZqTUdRNFkyVXpMVEJqTkdZdE5EWmxZaTA0TW1RNUxUTmlZakl6TVRSbU5EZGxZeUlzSW01dmJtTmxJam9pVkVWT1JXUkhhekJqYTJ4c1pIcFdSMWxWTVhkalNGSlZVekk1ZFZOWWF6SlVWa28yVGtWR1YyTnFSU0lzSW1oMGJTSTZJbEJQVTFRaUxDSm9kSFVpT2lKb2RIUndPaTh2ZDJseVpTNWpiMjA2TVRVMk1ESXZZMnhwWlc1MGN5OWhOall4WlRjNU56TTFaR000T1RCbUwyRmpZMlZ6Y3kxMGIydGxiaUlzSW1Ob1lXd2lPaUk0TkZOb1FuVm5VVFpOYVUxQ1VFVnFha3hCZUVGVmEyeG9RWHBMZFdKSFV5SjkuSW5EcUF5a3plaGh5ckhUejc0d1dGeDdMMG11eUpwSU53Tm9ObEdndnlDMkNzWWpCQlNadHRnMUZvTXpRcDlxVktPTjg0QUgxOTcxRjNvdDY0U05DQUEiLCJjbGllbnRfaWQiOiJpbTp3aXJlYXBwPU1HRXhOVEEyTUROaU1tUTVORGRoTm1KbU5HRmpOR0psTlRBMk1EWXhObU0vYTY2MWU3OTczNWRjODkwZkB3aXJlLmNvbSIsImFwaV92ZXJzaW9uIjozLCJzY29wZSI6IndpcmVfY2xpZW50X2lkIn0.pJ1gg3wocgnGSIC1hIxnmAEYWz5t20m7ibcYewEU9zVXwbrVIssd7fYLgEkbpEJcts-VXFBJCgflltOsa_t_Bw",
+  "token": "eyJhbGciOiJFZERTQSIsInR5cCI6ImF0K2p3dCIsImp3ayI6eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6ImdtNDZXQzJZY1N4MWdjbXYydUFKU2R4SlBsdkx4bUdjSjdVQlVOV0syb1EifX0.eyJpYXQiOjE2OTA3OTU2NzIsImV4cCI6MTY5ODU3MTY3MiwibmJmIjoxNjkwNzk1NjY3LCJpc3MiOiJodHRwOi8vd2lyZS5jb206MjMxNzYvY2xpZW50cy9lZjZhOTFhOTFkMzMzN2EvYWNjZXNzLXRva2VuIiwic3ViIjoiaW06d2lyZWFwcD1OalkzTlRWaE5HWXpNekU0TkdGak1EZ3lPR1E1WlRaaE9HTTNOell4TlRJL2VmNmE5MWE5MWQzMzM3YUB3aXJlLmNvbSIsImF1ZCI6Imh0dHA6Ly93aXJlLmNvbToyMzE3Ni9jbGllbnRzL2VmNmE5MWE5MWQzMzM3YS9hY2Nlc3MtdG9rZW4iLCJqdGkiOiIxMmJlOGE4ZS0xNjE5LTRkZWEtYmY4Yy1lMmY3YmFiMTljYzYiLCJub25jZSI6IlpYZ3ljMGRCV2xKUVJVeG5ZVzEzTldSNlJEWkhjMWRxWXpKbVpIa3pibEkiLCJjaGFsIjoiUG1QTDVpZkNIZUJ2b2VHVGo3aWRDaWVhQ2tPTnY5QmgiLCJjbmYiOnsia2lkIjoidXlsTUhqb2U4RlpZSmFZUVFNUGJBQUNXTWc2UGFUNEFkQVF4OHRncGRvQSJ9LCJwcm9vZiI6ImV5SmhiR2NpT2lKRlpFUlRRU0lzSW5SNWNDSTZJbVJ3YjNBcmFuZDBJaXdpYW5kcklqcDdJbXQwZVNJNklrOUxVQ0lzSW1OeWRpSTZJa1ZrTWpVMU1Ua2lMQ0o0SWpvaWNsZEpVRlJaYkZwTVJEQk9hbkpKUlVSM2JEWTBNbFJTU0RkU2VGaGlPV2RCYm1GcWJrOHdZV0pvYnlKOWZRLmV5SnBZWFFpT2pFMk9UQTNPVFUyTnpJc0ltVjRjQ0k2TVRZNU1EYzVPVEkzTWl3aWJtSm1Jam94Tmprd056azFOalkzTENKemRXSWlPaUpwYlRwM2FYSmxZWEJ3UFU1cVdUTk9WRlpvVGtkWmVrMTZSVFJPUjBacVRVUm5lVTlIVVRWYVZGcG9UMGROTTA1NldYaE9WRWt2WldZMllUa3hZVGt4WkRNek16ZGhRSGRwY21VdVkyOXRJaXdpYW5ScElqb2lZamRtWXpReE5HVXRNemMwT1MwME1qYzJMVGczTXpVdFpqZ3pNelU0WlRoaE1qaG1JaXdpYm05dVkyVWlPaUphV0dkNVl6QmtRbGRzU2xGU1ZYaHVXVmN4TTA1WFVqWlNSRnBJWXpGa2NWbDZTbTFhU0d0NllteEpJaXdpYUhSdElqb2lVRTlUVkNJc0ltaDBkU0k2SW1oMGRIQTZMeTkzYVhKbExtTnZiVG95TXpFM05pOWpiR2xsYm5SekwyVm1ObUU1TVdFNU1XUXpNek0zWVM5aFkyTmxjM010ZEc5clpXNGlMQ0pqYUdGc0lqb2lVRzFRVERWcFprTklaVUoyYjJWSFZHbzNhV1JEYVdWaFEydFBUblk1UW1naWZRLkQ4dHZZa3NfU2twcmQzWUxnRkhkYkh4Ymh6dVBsd0lfLWNsY3dmcURDWFNMdjEzaWlpa05vRm1CS2hEYk5EcmY4REh1SGZwbklEVWpBbm93VFQ5MUF3IiwiY2xpZW50X2lkIjoiaW06d2lyZWFwcD1OalkzTlRWaE5HWXpNekU0TkdGak1EZ3lPR1E1WlRaaE9HTTNOell4TlRJL2VmNmE5MWE5MWQzMzM3YUB3aXJlLmNvbSIsImFwaV92ZXJzaW9uIjozLCJzY29wZSI6IndpcmVfY2xpZW50X2lkIn0.PU-jXARlM5qYmtEu_U1htQtCiEZkWBEkXhdLQJRj3PkO-jgNw6EywAiUGes8ylnfkiqox6EtIG1xPqbpLqopCg",
   "type": "DPoP"
 }
 ```
@@ -342,43 +342,42 @@ dpop: ZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNkltUndiM0FyYW5kMElpd2lhbmRySWpwN0ltdD
 <details>
 <summary><b>Access token</b></summary>
 
-See it on [jwt.io](https://jwt.io/#id_token=eyJhbGciOiJFZERTQSIsInR5cCI6ImF0K2p3dCIsImp3ayI6eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Im52bnFvTEZPc0xGcEYzbEJDRVhpb0d1NGhuYUYxbENVU3F1T085RkU5MDAifX0.eyJpYXQiOjE2ODYwNTMyOTgsImV4cCI6MTY5MzgyOTI5OCwibmJmIjoxNjg2MDUzMjkzLCJpc3MiOiJodHRwOi8vd2lyZS5jb206MTU2MDIvY2xpZW50cy9hNjYxZTc5NzM1ZGM4OTBmL2FjY2Vzcy10b2tlbiIsInN1YiI6ImltOndpcmVhcHA9TUdFeE5UQTJNRE5pTW1RNU5EZGhObUptTkdGak5HSmxOVEEyTURZeE5tTS9hNjYxZTc5NzM1ZGM4OTBmQHdpcmUuY29tIiwiYXVkIjoiaHR0cDovL3dpcmUuY29tOjE1NjAyL2NsaWVudHMvYTY2MWU3OTczNWRjODkwZi9hY2Nlc3MtdG9rZW4iLCJqdGkiOiI2OThjMDg2MC1jM2E0LTQ2NGEtYmVkMy02NjdmOTViNzYyOTYiLCJub25jZSI6IlRFTkVkR2swY2tsbGR6VkdZVTF3Y0hSVVMyOXVTWGsyVFZKNk5FRldjakUiLCJjaGFsIjoiODRTaEJ1Z1E2TWlNQlBFampMQXhBVWtsaEF6S3ViR1MiLCJjbmYiOnsia2lkIjoiYkZBN08wbnctS3ZzYWxUdVJqTGg5aEUtd2dtQTJKR2E0SnhQbDBxVnpjZyJ9LCJwcm9vZiI6ImV5SmhiR2NpT2lKRlpFUlRRU0lzSW5SNWNDSTZJbVJ3YjNBcmFuZDBJaXdpYW5kcklqcDdJbXQwZVNJNklrOUxVQ0lzSW1OeWRpSTZJa1ZrTWpVMU1Ua2lMQ0o0SWpvaVVtdDNkREkyYzJKNk5EUlVSbmRGTUV4YWFHNVVhMVU0WTJkZlMyTnBWWEJFT1ZoWGVUQkZjVzh3TkNKOWZRLmV5SnBZWFFpT2pFMk9EWXdOVE15T1Rnc0ltVjRjQ0k2TVRZNE5qQTFOamc1T0N3aWJtSm1Jam94TmpnMk1EVXpNamt6TENKemRXSWlPaUpwYlRwM2FYSmxZWEJ3UFUxSFJYaE9WRUV5VFVST2FVMXRVVFZPUkdSb1RtMUtiVTVIUm1wT1IwcHNUbFJCTWsxRVdYaE9iVTB2WVRZMk1XVTNPVGN6TldSak9Ea3daa0IzYVhKbExtTnZiU0lzSW1wMGFTSTZJakZqTUdRNFkyVXpMVEJqTkdZdE5EWmxZaTA0TW1RNUxUTmlZakl6TVRSbU5EZGxZeUlzSW01dmJtTmxJam9pVkVWT1JXUkhhekJqYTJ4c1pIcFdSMWxWTVhkalNGSlZVekk1ZFZOWWF6SlVWa28yVGtWR1YyTnFSU0lzSW1oMGJTSTZJbEJQVTFRaUxDSm9kSFVpT2lKb2RIUndPaTh2ZDJseVpTNWpiMjA2TVRVMk1ESXZZMnhwWlc1MGN5OWhOall4WlRjNU56TTFaR000T1RCbUwyRmpZMlZ6Y3kxMGIydGxiaUlzSW1Ob1lXd2lPaUk0TkZOb1FuVm5VVFpOYVUxQ1VFVnFha3hCZUVGVmEyeG9RWHBMZFdKSFV5SjkuSW5EcUF5a3plaGh5ckhUejc0d1dGeDdMMG11eUpwSU53Tm9ObEdndnlDMkNzWWpCQlNadHRnMUZvTXpRcDlxVktPTjg0QUgxOTcxRjNvdDY0U05DQUEiLCJjbGllbnRfaWQiOiJpbTp3aXJlYXBwPU1HRXhOVEEyTUROaU1tUTVORGRoTm1KbU5HRmpOR0psTlRBMk1EWXhObU0vYTY2MWU3OTczNWRjODkwZkB3aXJlLmNvbSIsImFwaV92ZXJzaW9uIjozLCJzY29wZSI6IndpcmVfY2xpZW50X2lkIn0.pJ1gg3wocgnGSIC1hIxnmAEYWz5t20m7ibcYewEU9zVXwbrVIssd7fYLgEkbpEJcts-VXFBJCgflltOsa_t_Bw)
+See it on [jwt.io](https://jwt.io/#id_token=eyJhbGciOiJFZERTQSIsInR5cCI6ImF0K2p3dCIsImp3ayI6eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6ImdtNDZXQzJZY1N4MWdjbXYydUFKU2R4SlBsdkx4bUdjSjdVQlVOV0syb1EifX0.eyJpYXQiOjE2OTA3OTU2NzIsImV4cCI6MTY5ODU3MTY3MiwibmJmIjoxNjkwNzk1NjY3LCJpc3MiOiJodHRwOi8vd2lyZS5jb206MjMxNzYvY2xpZW50cy9lZjZhOTFhOTFkMzMzN2EvYWNjZXNzLXRva2VuIiwic3ViIjoiaW06d2lyZWFwcD1OalkzTlRWaE5HWXpNekU0TkdGak1EZ3lPR1E1WlRaaE9HTTNOell4TlRJL2VmNmE5MWE5MWQzMzM3YUB3aXJlLmNvbSIsImF1ZCI6Imh0dHA6Ly93aXJlLmNvbToyMzE3Ni9jbGllbnRzL2VmNmE5MWE5MWQzMzM3YS9hY2Nlc3MtdG9rZW4iLCJqdGkiOiIxMmJlOGE4ZS0xNjE5LTRkZWEtYmY4Yy1lMmY3YmFiMTljYzYiLCJub25jZSI6IlpYZ3ljMGRCV2xKUVJVeG5ZVzEzTldSNlJEWkhjMWRxWXpKbVpIa3pibEkiLCJjaGFsIjoiUG1QTDVpZkNIZUJ2b2VHVGo3aWRDaWVhQ2tPTnY5QmgiLCJjbmYiOnsia2lkIjoidXlsTUhqb2U4RlpZSmFZUVFNUGJBQUNXTWc2UGFUNEFkQVF4OHRncGRvQSJ9LCJwcm9vZiI6ImV5SmhiR2NpT2lKRlpFUlRRU0lzSW5SNWNDSTZJbVJ3YjNBcmFuZDBJaXdpYW5kcklqcDdJbXQwZVNJNklrOUxVQ0lzSW1OeWRpSTZJa1ZrTWpVMU1Ua2lMQ0o0SWpvaWNsZEpVRlJaYkZwTVJEQk9hbkpKUlVSM2JEWTBNbFJTU0RkU2VGaGlPV2RCYm1GcWJrOHdZV0pvYnlKOWZRLmV5SnBZWFFpT2pFMk9UQTNPVFUyTnpJc0ltVjRjQ0k2TVRZNU1EYzVPVEkzTWl3aWJtSm1Jam94Tmprd056azFOalkzTENKemRXSWlPaUpwYlRwM2FYSmxZWEJ3UFU1cVdUTk9WRlpvVGtkWmVrMTZSVFJPUjBacVRVUm5lVTlIVVRWYVZGcG9UMGROTTA1NldYaE9WRWt2WldZMllUa3hZVGt4WkRNek16ZGhRSGRwY21VdVkyOXRJaXdpYW5ScElqb2lZamRtWXpReE5HVXRNemMwT1MwME1qYzJMVGczTXpVdFpqZ3pNelU0WlRoaE1qaG1JaXdpYm05dVkyVWlPaUphV0dkNVl6QmtRbGRzU2xGU1ZYaHVXVmN4TTA1WFVqWlNSRnBJWXpGa2NWbDZTbTFhU0d0NllteEpJaXdpYUhSdElqb2lVRTlUVkNJc0ltaDBkU0k2SW1oMGRIQTZMeTkzYVhKbExtTnZiVG95TXpFM05pOWpiR2xsYm5SekwyVm1ObUU1TVdFNU1XUXpNek0zWVM5aFkyTmxjM010ZEc5clpXNGlMQ0pqYUdGc0lqb2lVRzFRVERWcFprTklaVUoyYjJWSFZHbzNhV1JEYVdWaFEydFBUblk1UW1naWZRLkQ4dHZZa3NfU2twcmQzWUxnRkhkYkh4Ymh6dVBsd0lfLWNsY3dmcURDWFNMdjEzaWlpa05vRm1CS2hEYk5EcmY4REh1SGZwbklEVWpBbm93VFQ5MUF3IiwiY2xpZW50X2lkIjoiaW06d2lyZWFwcD1OalkzTlRWaE5HWXpNekU0TkdGak1EZ3lPR1E1WlRaaE9HTTNOell4TlRJL2VmNmE5MWE5MWQzMzM3YUB3aXJlLmNvbSIsImFwaV92ZXJzaW9uIjozLCJzY29wZSI6IndpcmVfY2xpZW50X2lkIn0.PU-jXARlM5qYmtEu_U1htQtCiEZkWBEkXhdLQJRj3PkO-jgNw6EywAiUGes8ylnfkiqox6EtIG1xPqbpLqopCg)
 
 Raw:
 ```text
 eyJhbGciOiJFZERTQSIsInR5cCI6ImF0K2p3dCIsImp3ayI6eyJrdHkiOiJPS1Ai
-LCJjcnYiOiJFZDI1NTE5IiwieCI6Im52bnFvTEZPc0xGcEYzbEJDRVhpb0d1NGhu
-YUYxbENVU3F1T085RkU5MDAifX0.eyJpYXQiOjE2ODYwNTMyOTgsImV4cCI6MTY5
-MzgyOTI5OCwibmJmIjoxNjg2MDUzMjkzLCJpc3MiOiJodHRwOi8vd2lyZS5jb206
-MTU2MDIvY2xpZW50cy9hNjYxZTc5NzM1ZGM4OTBmL2FjY2Vzcy10b2tlbiIsInN1
-YiI6ImltOndpcmVhcHA9TUdFeE5UQTJNRE5pTW1RNU5EZGhObUptTkdGak5HSmxO
-VEEyTURZeE5tTS9hNjYxZTc5NzM1ZGM4OTBmQHdpcmUuY29tIiwiYXVkIjoiaHR0
-cDovL3dpcmUuY29tOjE1NjAyL2NsaWVudHMvYTY2MWU3OTczNWRjODkwZi9hY2Nl
-c3MtdG9rZW4iLCJqdGkiOiI2OThjMDg2MC1jM2E0LTQ2NGEtYmVkMy02NjdmOTVi
-NzYyOTYiLCJub25jZSI6IlRFTkVkR2swY2tsbGR6VkdZVTF3Y0hSVVMyOXVTWGsy
-VFZKNk5FRldjakUiLCJjaGFsIjoiODRTaEJ1Z1E2TWlNQlBFampMQXhBVWtsaEF6
-S3ViR1MiLCJjbmYiOnsia2lkIjoiYkZBN08wbnctS3ZzYWxUdVJqTGg5aEUtd2dt
-QTJKR2E0SnhQbDBxVnpjZyJ9LCJwcm9vZiI6ImV5SmhiR2NpT2lKRlpFUlRRU0lz
-SW5SNWNDSTZJbVJ3YjNBcmFuZDBJaXdpYW5kcklqcDdJbXQwZVNJNklrOUxVQ0lz
-SW1OeWRpSTZJa1ZrTWpVMU1Ua2lMQ0o0SWpvaVVtdDNkREkyYzJKNk5EUlVSbmRG
-TUV4YWFHNVVhMVU0WTJkZlMyTnBWWEJFT1ZoWGVUQkZjVzh3TkNKOWZRLmV5SnBZ
-WFFpT2pFMk9EWXdOVE15T1Rnc0ltVjRjQ0k2TVRZNE5qQTFOamc1T0N3aWJtSm1J
-am94TmpnMk1EVXpNamt6TENKemRXSWlPaUpwYlRwM2FYSmxZWEJ3UFUxSFJYaE9W
-RUV5VFVST2FVMXRVVFZPUkdSb1RtMUtiVTVIUm1wT1IwcHNUbFJCTWsxRVdYaE9i
-VTB2WVRZMk1XVTNPVGN6TldSak9Ea3daa0IzYVhKbExtTnZiU0lzSW1wMGFTSTZJ
-akZqTUdRNFkyVXpMVEJqTkdZdE5EWmxZaTA0TW1RNUxUTmlZakl6TVRSbU5EZGxZ
-eUlzSW01dmJtTmxJam9pVkVWT1JXUkhhekJqYTJ4c1pIcFdSMWxWTVhkalNGSlZV
-ekk1ZFZOWWF6SlVWa28yVGtWR1YyTnFSU0lzSW1oMGJTSTZJbEJQVTFRaUxDSm9k
-SFVpT2lKb2RIUndPaTh2ZDJseVpTNWpiMjA2TVRVMk1ESXZZMnhwWlc1MGN5OWhO
-all4WlRjNU56TTFaR000T1RCbUwyRmpZMlZ6Y3kxMGIydGxiaUlzSW1Ob1lXd2lP
-aUk0TkZOb1FuVm5VVFpOYVUxQ1VFVnFha3hCZUVGVmEyeG9RWHBMZFdKSFV5Sjku
-SW5EcUF5a3plaGh5ckhUejc0d1dGeDdMMG11eUpwSU53Tm9ObEdndnlDMkNzWWpC
-QlNadHRnMUZvTXpRcDlxVktPTjg0QUgxOTcxRjNvdDY0U05DQUEiLCJjbGllbnRf
-aWQiOiJpbTp3aXJlYXBwPU1HRXhOVEEyTUROaU1tUTVORGRoTm1KbU5HRmpOR0ps
-TlRBMk1EWXhObU0vYTY2MWU3OTczNWRjODkwZkB3aXJlLmNvbSIsImFwaV92ZXJz
-aW9uIjozLCJzY29wZSI6IndpcmVfY2xpZW50X2lkIn0.pJ1gg3wocgnGSIC1hIxn
-mAEYWz5t20m7ibcYewEU9zVXwbrVIssd7fYLgEkbpEJcts-VXFBJCgflltOsa_t_
-Bw
+LCJjcnYiOiJFZDI1NTE5IiwieCI6ImdtNDZXQzJZY1N4MWdjbXYydUFKU2R4SlBs
+dkx4bUdjSjdVQlVOV0syb1EifX0.eyJpYXQiOjE2OTA3OTU2NzIsImV4cCI6MTY5
+ODU3MTY3MiwibmJmIjoxNjkwNzk1NjY3LCJpc3MiOiJodHRwOi8vd2lyZS5jb206
+MjMxNzYvY2xpZW50cy9lZjZhOTFhOTFkMzMzN2EvYWNjZXNzLXRva2VuIiwic3Vi
+IjoiaW06d2lyZWFwcD1OalkzTlRWaE5HWXpNekU0TkdGak1EZ3lPR1E1WlRaaE9H
+TTNOell4TlRJL2VmNmE5MWE5MWQzMzM3YUB3aXJlLmNvbSIsImF1ZCI6Imh0dHA6
+Ly93aXJlLmNvbToyMzE3Ni9jbGllbnRzL2VmNmE5MWE5MWQzMzM3YS9hY2Nlc3Mt
+dG9rZW4iLCJqdGkiOiIxMmJlOGE4ZS0xNjE5LTRkZWEtYmY4Yy1lMmY3YmFiMTlj
+YzYiLCJub25jZSI6IlpYZ3ljMGRCV2xKUVJVeG5ZVzEzTldSNlJEWkhjMWRxWXpK
+bVpIa3pibEkiLCJjaGFsIjoiUG1QTDVpZkNIZUJ2b2VHVGo3aWRDaWVhQ2tPTnY5
+QmgiLCJjbmYiOnsia2lkIjoidXlsTUhqb2U4RlpZSmFZUVFNUGJBQUNXTWc2UGFU
+NEFkQVF4OHRncGRvQSJ9LCJwcm9vZiI6ImV5SmhiR2NpT2lKRlpFUlRRU0lzSW5S
+NWNDSTZJbVJ3YjNBcmFuZDBJaXdpYW5kcklqcDdJbXQwZVNJNklrOUxVQ0lzSW1O
+eWRpSTZJa1ZrTWpVMU1Ua2lMQ0o0SWpvaWNsZEpVRlJaYkZwTVJEQk9hbkpKUlVS
+M2JEWTBNbFJTU0RkU2VGaGlPV2RCYm1GcWJrOHdZV0pvYnlKOWZRLmV5SnBZWFFp
+T2pFMk9UQTNPVFUyTnpJc0ltVjRjQ0k2TVRZNU1EYzVPVEkzTWl3aWJtSm1Jam94
+Tmprd056azFOalkzTENKemRXSWlPaUpwYlRwM2FYSmxZWEJ3UFU1cVdUTk9WRlpv
+VGtkWmVrMTZSVFJPUjBacVRVUm5lVTlIVVRWYVZGcG9UMGROTTA1NldYaE9WRWt2
+WldZMllUa3hZVGt4WkRNek16ZGhRSGRwY21VdVkyOXRJaXdpYW5ScElqb2lZamRt
+WXpReE5HVXRNemMwT1MwME1qYzJMVGczTXpVdFpqZ3pNelU0WlRoaE1qaG1JaXdp
+Ym05dVkyVWlPaUphV0dkNVl6QmtRbGRzU2xGU1ZYaHVXVmN4TTA1WFVqWlNSRnBJ
+WXpGa2NWbDZTbTFhU0d0NllteEpJaXdpYUhSdElqb2lVRTlUVkNJc0ltaDBkU0k2
+SW1oMGRIQTZMeTkzYVhKbExtTnZiVG95TXpFM05pOWpiR2xsYm5SekwyVm1ObUU1
+TVdFNU1XUXpNek0zWVM5aFkyTmxjM010ZEc5clpXNGlMQ0pqYUdGc0lqb2lVRzFR
+VERWcFprTklaVUoyYjJWSFZHbzNhV1JEYVdWaFEydFBUblk1UW1naWZRLkQ4dHZZ
+a3NfU2twcmQzWUxnRkhkYkh4Ymh6dVBsd0lfLWNsY3dmcURDWFNMdjEzaWlpa05v
+Rm1CS2hEYk5EcmY4REh1SGZwbklEVWpBbm93VFQ5MUF3IiwiY2xpZW50X2lkIjoi
+aW06d2lyZWFwcD1OalkzTlRWaE5HWXpNekU0TkdGak1EZ3lPR1E1WlRaaE9HTTNO
+ell4TlRJL2VmNmE5MWE5MWQzMzM3YUB3aXJlLmNvbSIsImFwaV92ZXJzaW9uIjoz
+LCJzY29wZSI6IndpcmVfY2xpZW50X2lkIn0.PU-jXARlM5qYmtEu_U1htQtCiEZk
+WBEkXhdLQJRj3PkO-jgNw6EywAiUGes8ylnfkiqox6EtIG1xPqbpLqopCg
 ```
 
 Decoded:
@@ -389,7 +388,7 @@ Decoded:
   "jwk": {
     "crv": "Ed25519",
     "kty": "OKP",
-    "x": "nvnqoLFOsLFpF3lBCEXioGu4hnaF1lCUSquOO9FE900"
+    "x": "gm46WC2YcSx1gcmv2uAJSdxJPlvLxmGcJ7UBUNWK2oQ"
   },
   "typ": "at+jwt"
 }
@@ -398,21 +397,21 @@ Decoded:
 ```json
 {
   "api_version": 3,
-  "aud": "http://wire.com:15602/clients/a661e79735dc890f/access-token",
-  "chal": "84ShBugQ6MiMBPEjjLAxAUklhAzKubGS",
-  "client_id": "im:wireapp=MGExNTA2MDNiMmQ5NDdhNmJmNGFjNGJlNTA2MDYxNmM/a661e79735dc890f@wire.com",
+  "aud": "http://wire.com:23176/clients/ef6a91a91d3337a/access-token",
+  "chal": "PmPL5ifCHeBvoeGTj7idCieaCkONv9Bh",
+  "client_id": "im:wireapp=NjY3NTVhNGYzMzE4NGFjMDgyOGQ5ZTZhOGM3NzYxNTI/ef6a91a91d3337a@wire.com",
   "cnf": {
-    "kid": "bFA7O0nw-KvsalTuRjLh9hE-wgmA2JGa4JxPl0qVzcg"
+    "kid": "uylMHjoe8FZYJaYQQMPbAACWMg6PaT4AdAQx8tgpdoA"
   },
-  "exp": 1693829298,
-  "iat": 1686053298,
-  "iss": "http://wire.com:15602/clients/a661e79735dc890f/access-token",
-  "jti": "698c0860-c3a4-464a-bed3-667f95b76296",
-  "nbf": 1686053293,
-  "nonce": "TENEdGk0cklldzVGYU1wcHRUS29uSXk2TVJ6NEFWcjE",
-  "proof": "eyJhbGciOiJFZERTQSIsInR5cCI6ImRwb3Arand0IiwiandrIjp7Imt0eSI6Ik9LUCIsImNydiI6IkVkMjU1MTkiLCJ4IjoiUmt3dDI2c2J6NDRURndFMExaaG5Ua1U4Y2dfS2NpVXBEOVhXeTBFcW8wNCJ9fQ.eyJpYXQiOjE2ODYwNTMyOTgsImV4cCI6MTY4NjA1Njg5OCwibmJmIjoxNjg2MDUzMjkzLCJzdWIiOiJpbTp3aXJlYXBwPU1HRXhOVEEyTUROaU1tUTVORGRoTm1KbU5HRmpOR0psTlRBMk1EWXhObU0vYTY2MWU3OTczNWRjODkwZkB3aXJlLmNvbSIsImp0aSI6IjFjMGQ4Y2UzLTBjNGYtNDZlYi04MmQ5LTNiYjIzMTRmNDdlYyIsIm5vbmNlIjoiVEVORWRHazBja2xsZHpWR1lVMXdjSFJVUzI5dVNYazJUVko2TkVGV2NqRSIsImh0bSI6IlBPU1QiLCJodHUiOiJodHRwOi8vd2lyZS5jb206MTU2MDIvY2xpZW50cy9hNjYxZTc5NzM1ZGM4OTBmL2FjY2Vzcy10b2tlbiIsImNoYWwiOiI4NFNoQnVnUTZNaU1CUEVqakxBeEFVa2xoQXpLdWJHUyJ9.InDqAykzehhyrHTz74wWFx7L0muyJpINwNoNlGgvyC2CsYjBBSZttg1FoMzQp9qVKON84AH1971F3ot64SNCAA",
+  "exp": 1698571672,
+  "iat": 1690795672,
+  "iss": "http://wire.com:23176/clients/ef6a91a91d3337a/access-token",
+  "jti": "12be8a8e-1619-4dea-bf8c-e2f7bab19cc6",
+  "nbf": 1690795667,
+  "nonce": "ZXgyc0dBWlJQRUxnYW13NWR6RDZHc1dqYzJmZHkzblI",
+  "proof": "eyJhbGciOiJFZERTQSIsInR5cCI6ImRwb3Arand0IiwiandrIjp7Imt0eSI6Ik9LUCIsImNydiI6IkVkMjU1MTkiLCJ4IjoicldJUFRZbFpMRDBOanJJRUR3bDY0MlRSSDdSeFhiOWdBbmFqbk8wYWJobyJ9fQ.eyJpYXQiOjE2OTA3OTU2NzIsImV4cCI6MTY5MDc5OTI3MiwibmJmIjoxNjkwNzk1NjY3LCJzdWIiOiJpbTp3aXJlYXBwPU5qWTNOVFZoTkdZek16RTROR0ZqTURneU9HUTVaVFpoT0dNM056WXhOVEkvZWY2YTkxYTkxZDMzMzdhQHdpcmUuY29tIiwianRpIjoiYjdmYzQxNGUtMzc0OS00Mjc2LTg3MzUtZjgzMzU4ZThhMjhmIiwibm9uY2UiOiJaWGd5YzBkQldsSlFSVXhuWVcxM05XUjZSRFpIYzFkcVl6Sm1aSGt6YmxJIiwiaHRtIjoiUE9TVCIsImh0dSI6Imh0dHA6Ly93aXJlLmNvbToyMzE3Ni9jbGllbnRzL2VmNmE5MWE5MWQzMzM3YS9hY2Nlc3MtdG9rZW4iLCJjaGFsIjoiUG1QTDVpZkNIZUJ2b2VHVGo3aWRDaWVhQ2tPTnY5QmgifQ.D8tvYks_Skprd3YLgFHdbHxbhzuPlwI_-clcwfqDCXSLv13iiikNoFmBKhDbNDrf8DHuHfpnIDUjAnowTT91Aw",
   "scope": "wire_client_id",
-  "sub": "im:wireapp=MGExNTA2MDNiMmQ5NDdhNmJmNGFjNGJlNTA2MDYxNmM/a661e79735dc890f@wire.com"
+  "sub": "im:wireapp=NjY3NTVhNGYzMzE4NGFjMDgyOGQ5ZTZhOGM3NzYxNTI/ef6a91a91d3337a@wire.com"
 }
 ```
 
@@ -420,10 +419,10 @@ Decoded:
 ✅ Signature Verified with key:
 ```text
 -----BEGIN PRIVATE KEY-----
-MC4CAQAwBQYDK2VwBCIEIBwZ8T4QDljhdXARTbyTCNA3IVGShicMaZSJGtQuKArT
+MC4CAQAwBQYDK2VwBCIEIJQAVCLHVcll1S8HQnyL2aLzfxi2L+kw04H+I9X1Mr6p
 -----END PRIVATE KEY-----
 -----BEGIN PUBLIC KEY-----
-MCowBQYDK2VwAyEAnvnqoLFOsLFpF3lBCEXioGu4hnaF1lCUSquOO9FE900=
+MCowBQYDK2VwAyEAgm46WC2YcSx1gcmv2uAJSdxJPlvLxmGcJ7UBUNWK2oQ=
 -----END PUBLIC KEY-----
 ```
 
@@ -433,28 +432,28 @@ MCowBQYDK2VwAyEAnvnqoLFOsLFpF3lBCEXioGu4hnaF1lCUSquOO9FE900=
 ### Client provides access token
 #### 16. validate Dpop challenge (clientId)
 ```http request
-POST https://stepca:33067/acme/wire/challenge/VZ9OvDd8uCSXMXjXVMfQg63TLUnxGZKk/x0gGlwzcz1VJWjgD9dM5RIuoSsLU4yva
+POST https://stepca:32787/acme/wire/challenge/VRaT4cBr1eYvRHzU2nXAyT2pUgzUc9ES/vrVPmwGhchmsuKJffwy0NASsR643ivxB
                          /acme/{acme-provisioner}/challenge/{authz-id}/{challenge-id}
 content-type: application/jose+json
 ```
 ```json
 {
-  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMzMDY3L2FjbWUvd2lyZS9hY2NvdW50LzNmOFAyQTMzeEFNVFVWbk5MSlRaZUhUQ2p3MDhXeHU2IiwidHlwIjoiSldUIiwibm9uY2UiOiJOa1JYWjFOT05qUTFRVEJNTTNscGVVSjRRa2xtWVdOWlV6QnRSemt3VUdnIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzMwNjcvYWNtZS93aXJlL2NoYWxsZW5nZS9WWjlPdkRkOHVDU1hNWGpYVk1mUWc2M1RMVW54R1pLay94MGdHbHd6Y3oxVkpXamdEOWRNNVJJdW9Tc0xVNHl2YSJ9",
-  "payload": "eyJhY2Nlc3NfdG9rZW4iOiJleUpoYkdjaU9pSkZaRVJUUVNJc0luUjVjQ0k2SW1GMEsycDNkQ0lzSW1wM2F5STZleUpyZEhraU9pSlBTMUFpTENKamNuWWlPaUpGWkRJMU5URTVJaXdpZUNJNkltNTJibkZ2VEVaUGMweEdjRVl6YkVKRFJWaHBiMGQxTkdodVlVWXhiRU5WVTNGMVQwODVSa1U1TURBaWZYMC5leUpwWVhRaU9qRTJPRFl3TlRNeU9UZ3NJbVY0Y0NJNk1UWTVNemd5T1RJNU9Dd2libUptSWpveE5qZzJNRFV6TWprekxDSnBjM01pT2lKb2RIUndPaTh2ZDJseVpTNWpiMjA2TVRVMk1ESXZZMnhwWlc1MGN5OWhOall4WlRjNU56TTFaR000T1RCbUwyRmpZMlZ6Y3kxMGIydGxiaUlzSW5OMVlpSTZJbWx0T25kcGNtVmhjSEE5VFVkRmVFNVVRVEpOUkU1cFRXMVJOVTVFWkdoT2JVcHRUa2RHYWs1SFNteE9WRUV5VFVSWmVFNXRUUzloTmpZeFpUYzVOek0xWkdNNE9UQm1RSGRwY21VdVkyOXRJaXdpWVhWa0lqb2lhSFIwY0RvdkwzZHBjbVV1WTI5dE9qRTFOakF5TDJOc2FXVnVkSE12WVRZMk1XVTNPVGN6TldSak9Ea3daaTloWTJObGMzTXRkRzlyWlc0aUxDSnFkR2tpT2lJMk9UaGpNRGcyTUMxak0yRTBMVFEyTkdFdFltVmtNeTAyTmpkbU9UVmlOell5T1RZaUxDSnViMjVqWlNJNklsUkZUa1ZrUjJzd1kydHNiR1I2VmtkWlZURjNZMGhTVlZNeU9YVlRXR3N5VkZaS05rNUZSbGRqYWtVaUxDSmphR0ZzSWpvaU9EUlRhRUoxWjFFMlRXbE5RbEJGYW1wTVFYaEJWV3RzYUVGNlMzVmlSMU1pTENKamJtWWlPbnNpYTJsa0lqb2lZa1pCTjA4d2JuY3RTM1p6WVd4VWRWSnFUR2c1YUVVdGQyZHRRVEpLUjJFMFNuaFFiREJ4Vm5walp5SjlMQ0p3Y205dlppSTZJbVY1U21oaVIyTnBUMmxLUmxwRlVsUlJVMGx6U1c1U05XTkRTVFpKYlZKM1lqTkJjbUZ1WkRCSmFYZHBZVzVrY2tscWNEZEpiWFF3WlZOSk5rbHJPVXhWUTBselNXMU9lV1JwU1RaSmExWnJUV3BWTVUxVWEybE1RMG8wU1dwdmFWVnRkRE5rUkVreVl6SktOazVFVWxWU2JtUkdUVVY0WVdGSE5WVmhNVlUwV1RKa1psTXlUbkJXV0VKRlQxWm9XR1ZVUWtaalZ6aDNUa05LT1daUkxtVjVTbkJaV0ZGcFQycEZNazlFV1hkT1ZFMTVUMVJuYzBsdFZqUmpRMGsyVFZSWk5FNXFRVEZPYW1jMVQwTjNhV0p0U20xSmFtOTRUbXBuTWsxRVZYcE5hbXQ2VEVOS2VtUlhTV2xQYVVwd1lsUndNMkZZU214WldFSjNVRlV4U0ZKWWFFOVdSVVY1VkZWU1QyRlZNWFJWVkZaUFVrZFNiMVJ0TVV0aVZUVklVbTF3VDFJd2NITlViRkpDVFdzeFJWZFlhRTlpVlRCMldWUlpNazFYVlROUFZHTjZUbGRTYWs5RWEzZGFhMEl6WVZoS2JFeHRUblppVTBselNXMXdNR0ZUU1RaSmFrWnFUVWRSTkZreVZYcE1WRUpxVGtkWmRFNUVXbXhaYVRBMFRXMVJOVXhVVG1sWmFrbDZUVlJTYlU1RVpHeFplVWx6U1cwMWRtSnRUbXhKYW05cFZrVldUMUpYVWtoaGVrSnFZVEo0YzFwSWNGZFNNV3hXVFZoa2FsTkdTbFpWZWtrMVpGWk9XV0Y2U2xWV2EyOHlWR3RXUjFZeVRuRlNVMGx6U1cxb01HSlRTVFpKYkVKUVZURlJhVXhEU205a1NGVnBUMmxLYjJSSVVuZFBhVGgyWkRKc2VWcFROV3BpTWpBMlRWUlZNazFFU1haWk1uaHdXbGMxTUdONU9XaE9hbGw0V2xSak5VNTZUVEZhUjAwMFQxUkNiVXd5Um1wWk1sWjZZM2t4TUdJeWRHeGlhVWx6U1cxT2IxbFhkMmxQYVVrMFRrWk9iMUZ1Vm01VlZGcE9ZVlV4UTFWRlZuRmhhM2hDWlVWR1ZtRXllRzlSV0hCTVpGZEtTRlY1U2prdVNXNUVjVUY1YTNwbGFHaDVja2hVZWpjMGQxZEdlRGRNTUcxMWVVcHdTVTUzVG05T2JFZG5kbmxETWtOeldXcENRbE5hZEhSbk1VWnZUWHBSY0RseFZrdFBUamcwUVVneE9UY3hSak52ZERZMFUwNURRVUVpTENKamJHbGxiblJmYVdRaU9pSnBiVHAzYVhKbFlYQndQVTFIUlhoT1ZFRXlUVVJPYVUxdFVUVk9SR1JvVG0xS2JVNUhSbXBPUjBwc1RsUkJNazFFV1hoT2JVMHZZVFkyTVdVM09UY3pOV1JqT0Rrd1prQjNhWEpsTG1OdmJTSXNJbUZ3YVY5MlpYSnphVzl1SWpvekxDSnpZMjl3WlNJNkluZHBjbVZmWTJ4cFpXNTBYMmxrSW4wLnBKMWdnM3dvY2duR1NJQzFoSXhubUFFWVd6NXQyMG03aWJjWWV3RVU5elZYd2JyVklzc2Q3ZllMZ0VrYnBFSmN0cy1WWEZCSkNnZmxsdE9zYV90X0J3In0",
-  "signature": "O1dQvUsVtYbke-mB-rtoqhNWHkrNVUS16_L0PZC6Qcb90YUVxVQwYT3OKnPxZXuYmpCRePjygYkNa6eOWhhIBA"
+  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMyNzg3L2FjbWUvd2lyZS9hY2NvdW50L0lZRk5jNEEwYWVTcEhPVmFxT0wzNjZPb1ZOQlBVczFmIiwidHlwIjoiSldUIiwibm9uY2UiOiJjamx6UlhsRFdEbERZWEJDVFhBeFJscGtUV2RoTmtWR2R6bGlkbFprTWxvIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI3ODcvYWNtZS93aXJlL2NoYWxsZW5nZS9WUmFUNGNCcjFlWXZSSHpVMm5YQXlUMnBVZ3pVYzlFUy92clZQbXdHaGNobXN1S0pmZnd5ME5BU3NSNjQzaXZ4QiJ9",
+  "payload": "eyJhY2Nlc3NfdG9rZW4iOiJleUpoYkdjaU9pSkZaRVJUUVNJc0luUjVjQ0k2SW1GMEsycDNkQ0lzSW1wM2F5STZleUpyZEhraU9pSlBTMUFpTENKamNuWWlPaUpGWkRJMU5URTVJaXdpZUNJNkltZHRORFpYUXpKWlkxTjRNV2RqYlhZeWRVRktVMlI0U2xCc2RreDRiVWRqU2pkVlFsVk9WMHN5YjFFaWZYMC5leUpwWVhRaU9qRTJPVEEzT1RVMk56SXNJbVY0Y0NJNk1UWTVPRFUzTVRZM01pd2libUptSWpveE5qa3dOemsxTmpZM0xDSnBjM01pT2lKb2RIUndPaTh2ZDJseVpTNWpiMjA2TWpNeE56WXZZMnhwWlc1MGN5OWxaalpoT1RGaE9URmtNek16TjJFdllXTmpaWE56TFhSdmEyVnVJaXdpYzNWaUlqb2lhVzA2ZDJseVpXRndjRDFPYWxrelRsUldhRTVIV1hwTmVrVTBUa2RHYWsxRVozbFBSMUUxV2xSYWFFOUhUVE5PZWxsNFRsUkpMMlZtTm1FNU1XRTVNV1F6TXpNM1lVQjNhWEpsTG1OdmJTSXNJbUYxWkNJNkltaDBkSEE2THk5M2FYSmxMbU52YlRveU16RTNOaTlqYkdsbGJuUnpMMlZtTm1FNU1XRTVNV1F6TXpNM1lTOWhZMk5sYzNNdGRHOXJaVzRpTENKcWRHa2lPaUl4TW1KbE9HRTRaUzB4TmpFNUxUUmtaV0V0WW1ZNFl5MWxNbVkzWW1GaU1UbGpZellpTENKdWIyNWpaU0k2SWxwWVozbGpNR1JDVjJ4S1VWSlZlRzVaVnpFelRsZFNObEpFV2toak1XUnhXWHBLYlZwSWEzcGliRWtpTENKamFHRnNJam9pVUcxUVREVnBaa05JWlVKMmIyVkhWR28zYVdSRGFXVmhRMnRQVG5ZNVFtZ2lMQ0pqYm1ZaU9uc2lhMmxrSWpvaWRYbHNUVWhxYjJVNFJscFpTbUZaVVZGTlVHSkJRVU5YVFdjMlVHRlVORUZrUVZGNE9IUm5jR1J2UVNKOUxDSndjbTl2WmlJNkltVjVTbWhpUjJOcFQybEtSbHBGVWxSUlUwbHpTVzVTTldORFNUWkpiVkozWWpOQmNtRnVaREJKYVhkcFlXNWtja2xxY0RkSmJYUXdaVk5KTmtsck9VeFZRMGx6U1cxT2VXUnBTVFpKYTFaclRXcFZNVTFVYTJsTVEwbzBTV3B2YVdOc1pFcFZSbEphWWtad1RWSkVRazloYmtwS1VsVlNNMkpFV1RCTmJGSlRVMFJrVTJWR2FHbFBWMlJDWW0xR2NXSnJPSGRaVjBwdllubEtPV1pSTG1WNVNuQlpXRkZwVDJwRk1rOVVRVE5QVkZVeVRucEpjMGx0VmpSalEwazJUVlJaTlUxRVl6VlBWRWt6VFdsM2FXSnRTbTFKYW05NFRtcHJkMDU2YXpGT2Fsa3pURU5LZW1SWFNXbFBhVXB3WWxSd00yRllTbXhaV0VKM1VGVTFjVmRVVGs5V1JscHZWR3RrV21Wck1UWlNWRkpQVWpCYWNWUlZVbTVsVlRsSVZWUldZVlpHY0c5VU1HUk9UVEExTmxkWWFFOVdSV3QyV2xkWk1sbFVhM2haVkd0NFdrUk5lazE2WkdoUlNHUndZMjFWZFZreU9YUkphWGRwWVc1U2NFbHFiMmxaYW1SdFdYcFJlRTVIVlhSTmVtTXdUMU13TUUxcVl6Sk1WR2N6VFhwVmRGcHFaM3BOZWxVMFdsUm9hRTFxYUcxSmFYZHBZbTA1ZFZreVZXbFBhVXBoVjBka05WbDZRbXRSYkdSelUyeEdVMVpZYUhWWFZtTjRUVEExV0ZWcVdsTlNSbkJKV1hwR2EyTldiRFpUYlRGaFUwZDBObGx0ZUVwSmFYZHBZVWhTZEVscWIybFZSVGxVVmtOSmMwbHRhREJrVTBrMlNXMW9NR1JJUVRaTWVUa3pZVmhLYkV4dFRuWmlWRzk1VFhwRk0wNXBPV3BpUjJ4c1ltNVNla3d5Vm0xT2JVVTFUVmRGTlUxWFVYcE5lazB6V1ZNNWFGa3lUbXhqTTAxMFpFYzVjbHBYTkdsTVEwcHFZVWRHYzBscWIybFZSekZSVkVSV2NGcHJUa2xhVlVveVlqSldTRlpIYnpOaFYxSkVZVmRXYUZFeWRGQlVibGsxVVcxbmFXWlJMa1E0ZEhaWmEzTmZVMnR3Y21ReldVeG5Sa2hrWWtoNFltaDZkVkJzZDBsZkxXTnNZM2RtY1VSRFdGTk1kakV6YVdscGEwNXZSbTFDUzJoRVlrNUVjbVk0UkVoMVNHWndia2xFVldwQmJtOTNWRlE1TVVGM0lpd2lZMnhwWlc1MFgybGtJam9pYVcwNmQybHlaV0Z3Y0QxT2Fsa3pUbFJXYUU1SFdYcE5la1UwVGtkR2FrMUVaM2xQUjFFMVdsUmFhRTlIVFROT2VsbDRUbFJKTDJWbU5tRTVNV0U1TVdRek16TTNZVUIzYVhKbExtTnZiU0lzSW1Gd2FWOTJaWEp6YVc5dUlqb3pMQ0p6WTI5d1pTSTZJbmRwY21WZlkyeHBaVzUwWDJsa0luMC5QVS1qWEFSbE01cVltdEV1X1UxaHRRdENpRVprV0JFa1hoZExRSlJqM1BrTy1qZ053NkV5d0FpVUdlczh5bG5ma2lxb3g2RXRJRzF4UHFicExxb3BDZyJ9",
+  "signature": "SMejFykGTjAzRc7CirmWO9hm4oMBfQzeMxuNE54_WmTPNvmZdxiBIvUKl8yk7zUsxUxGhh0XAi-auOi74E1UCQ"
 }
 ```
 ```json
 {
   "payload": {
-    "access_token": "eyJhbGciOiJFZERTQSIsInR5cCI6ImF0K2p3dCIsImp3ayI6eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Im52bnFvTEZPc0xGcEYzbEJDRVhpb0d1NGhuYUYxbENVU3F1T085RkU5MDAifX0.eyJpYXQiOjE2ODYwNTMyOTgsImV4cCI6MTY5MzgyOTI5OCwibmJmIjoxNjg2MDUzMjkzLCJpc3MiOiJodHRwOi8vd2lyZS5jb206MTU2MDIvY2xpZW50cy9hNjYxZTc5NzM1ZGM4OTBmL2FjY2Vzcy10b2tlbiIsInN1YiI6ImltOndpcmVhcHA9TUdFeE5UQTJNRE5pTW1RNU5EZGhObUptTkdGak5HSmxOVEEyTURZeE5tTS9hNjYxZTc5NzM1ZGM4OTBmQHdpcmUuY29tIiwiYXVkIjoiaHR0cDovL3dpcmUuY29tOjE1NjAyL2NsaWVudHMvYTY2MWU3OTczNWRjODkwZi9hY2Nlc3MtdG9rZW4iLCJqdGkiOiI2OThjMDg2MC1jM2E0LTQ2NGEtYmVkMy02NjdmOTViNzYyOTYiLCJub25jZSI6IlRFTkVkR2swY2tsbGR6VkdZVTF3Y0hSVVMyOXVTWGsyVFZKNk5FRldjakUiLCJjaGFsIjoiODRTaEJ1Z1E2TWlNQlBFampMQXhBVWtsaEF6S3ViR1MiLCJjbmYiOnsia2lkIjoiYkZBN08wbnctS3ZzYWxUdVJqTGg5aEUtd2dtQTJKR2E0SnhQbDBxVnpjZyJ9LCJwcm9vZiI6ImV5SmhiR2NpT2lKRlpFUlRRU0lzSW5SNWNDSTZJbVJ3YjNBcmFuZDBJaXdpYW5kcklqcDdJbXQwZVNJNklrOUxVQ0lzSW1OeWRpSTZJa1ZrTWpVMU1Ua2lMQ0o0SWpvaVVtdDNkREkyYzJKNk5EUlVSbmRGTUV4YWFHNVVhMVU0WTJkZlMyTnBWWEJFT1ZoWGVUQkZjVzh3TkNKOWZRLmV5SnBZWFFpT2pFMk9EWXdOVE15T1Rnc0ltVjRjQ0k2TVRZNE5qQTFOamc1T0N3aWJtSm1Jam94TmpnMk1EVXpNamt6TENKemRXSWlPaUpwYlRwM2FYSmxZWEJ3UFUxSFJYaE9WRUV5VFVST2FVMXRVVFZPUkdSb1RtMUtiVTVIUm1wT1IwcHNUbFJCTWsxRVdYaE9iVTB2WVRZMk1XVTNPVGN6TldSak9Ea3daa0IzYVhKbExtTnZiU0lzSW1wMGFTSTZJakZqTUdRNFkyVXpMVEJqTkdZdE5EWmxZaTA0TW1RNUxUTmlZakl6TVRSbU5EZGxZeUlzSW01dmJtTmxJam9pVkVWT1JXUkhhekJqYTJ4c1pIcFdSMWxWTVhkalNGSlZVekk1ZFZOWWF6SlVWa28yVGtWR1YyTnFSU0lzSW1oMGJTSTZJbEJQVTFRaUxDSm9kSFVpT2lKb2RIUndPaTh2ZDJseVpTNWpiMjA2TVRVMk1ESXZZMnhwWlc1MGN5OWhOall4WlRjNU56TTFaR000T1RCbUwyRmpZMlZ6Y3kxMGIydGxiaUlzSW1Ob1lXd2lPaUk0TkZOb1FuVm5VVFpOYVUxQ1VFVnFha3hCZUVGVmEyeG9RWHBMZFdKSFV5SjkuSW5EcUF5a3plaGh5ckhUejc0d1dGeDdMMG11eUpwSU53Tm9ObEdndnlDMkNzWWpCQlNadHRnMUZvTXpRcDlxVktPTjg0QUgxOTcxRjNvdDY0U05DQUEiLCJjbGllbnRfaWQiOiJpbTp3aXJlYXBwPU1HRXhOVEEyTUROaU1tUTVORGRoTm1KbU5HRmpOR0psTlRBMk1EWXhObU0vYTY2MWU3OTczNWRjODkwZkB3aXJlLmNvbSIsImFwaV92ZXJzaW9uIjozLCJzY29wZSI6IndpcmVfY2xpZW50X2lkIn0.pJ1gg3wocgnGSIC1hIxnmAEYWz5t20m7ibcYewEU9zVXwbrVIssd7fYLgEkbpEJcts-VXFBJCgflltOsa_t_Bw"
+    "access_token": "eyJhbGciOiJFZERTQSIsInR5cCI6ImF0K2p3dCIsImp3ayI6eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6ImdtNDZXQzJZY1N4MWdjbXYydUFKU2R4SlBsdkx4bUdjSjdVQlVOV0syb1EifX0.eyJpYXQiOjE2OTA3OTU2NzIsImV4cCI6MTY5ODU3MTY3MiwibmJmIjoxNjkwNzk1NjY3LCJpc3MiOiJodHRwOi8vd2lyZS5jb206MjMxNzYvY2xpZW50cy9lZjZhOTFhOTFkMzMzN2EvYWNjZXNzLXRva2VuIiwic3ViIjoiaW06d2lyZWFwcD1OalkzTlRWaE5HWXpNekU0TkdGak1EZ3lPR1E1WlRaaE9HTTNOell4TlRJL2VmNmE5MWE5MWQzMzM3YUB3aXJlLmNvbSIsImF1ZCI6Imh0dHA6Ly93aXJlLmNvbToyMzE3Ni9jbGllbnRzL2VmNmE5MWE5MWQzMzM3YS9hY2Nlc3MtdG9rZW4iLCJqdGkiOiIxMmJlOGE4ZS0xNjE5LTRkZWEtYmY4Yy1lMmY3YmFiMTljYzYiLCJub25jZSI6IlpYZ3ljMGRCV2xKUVJVeG5ZVzEzTldSNlJEWkhjMWRxWXpKbVpIa3pibEkiLCJjaGFsIjoiUG1QTDVpZkNIZUJ2b2VHVGo3aWRDaWVhQ2tPTnY5QmgiLCJjbmYiOnsia2lkIjoidXlsTUhqb2U4RlpZSmFZUVFNUGJBQUNXTWc2UGFUNEFkQVF4OHRncGRvQSJ9LCJwcm9vZiI6ImV5SmhiR2NpT2lKRlpFUlRRU0lzSW5SNWNDSTZJbVJ3YjNBcmFuZDBJaXdpYW5kcklqcDdJbXQwZVNJNklrOUxVQ0lzSW1OeWRpSTZJa1ZrTWpVMU1Ua2lMQ0o0SWpvaWNsZEpVRlJaYkZwTVJEQk9hbkpKUlVSM2JEWTBNbFJTU0RkU2VGaGlPV2RCYm1GcWJrOHdZV0pvYnlKOWZRLmV5SnBZWFFpT2pFMk9UQTNPVFUyTnpJc0ltVjRjQ0k2TVRZNU1EYzVPVEkzTWl3aWJtSm1Jam94Tmprd056azFOalkzTENKemRXSWlPaUpwYlRwM2FYSmxZWEJ3UFU1cVdUTk9WRlpvVGtkWmVrMTZSVFJPUjBacVRVUm5lVTlIVVRWYVZGcG9UMGROTTA1NldYaE9WRWt2WldZMllUa3hZVGt4WkRNek16ZGhRSGRwY21VdVkyOXRJaXdpYW5ScElqb2lZamRtWXpReE5HVXRNemMwT1MwME1qYzJMVGczTXpVdFpqZ3pNelU0WlRoaE1qaG1JaXdpYm05dVkyVWlPaUphV0dkNVl6QmtRbGRzU2xGU1ZYaHVXVmN4TTA1WFVqWlNSRnBJWXpGa2NWbDZTbTFhU0d0NllteEpJaXdpYUhSdElqb2lVRTlUVkNJc0ltaDBkU0k2SW1oMGRIQTZMeTkzYVhKbExtTnZiVG95TXpFM05pOWpiR2xsYm5SekwyVm1ObUU1TVdFNU1XUXpNek0zWVM5aFkyTmxjM010ZEc5clpXNGlMQ0pqYUdGc0lqb2lVRzFRVERWcFprTklaVUoyYjJWSFZHbzNhV1JEYVdWaFEydFBUblk1UW1naWZRLkQ4dHZZa3NfU2twcmQzWUxnRkhkYkh4Ymh6dVBsd0lfLWNsY3dmcURDWFNMdjEzaWlpa05vRm1CS2hEYk5EcmY4REh1SGZwbklEVWpBbm93VFQ5MUF3IiwiY2xpZW50X2lkIjoiaW06d2lyZWFwcD1OalkzTlRWaE5HWXpNekU0TkdGak1EZ3lPR1E1WlRaaE9HTTNOell4TlRJL2VmNmE5MWE5MWQzMzM3YUB3aXJlLmNvbSIsImFwaV92ZXJzaW9uIjozLCJzY29wZSI6IndpcmVfY2xpZW50X2lkIn0.PU-jXARlM5qYmtEu_U1htQtCiEZkWBEkXhdLQJRj3PkO-jgNw6EywAiUGes8ylnfkiqox6EtIG1xPqbpLqopCg"
   },
   "protected": {
     "alg": "EdDSA",
-    "kid": "https://stepca:33067/acme/wire/account/3f8P2A33xAMTUVnNLJTZeHTCjw08Wxu6",
-    "nonce": "NkRXZ1NONjQ1QTBMM3lpeUJ4QklmYWNZUzBtRzkwUGg",
+    "kid": "https://stepca:32787/acme/wire/account/IYFNc4A0aeSpHOVaqOL366OoVNBPUs1f",
+    "nonce": "cjlzRXlDWDlDYXBCTXAxRlpkTWdhNkVGdzlidlZkMlo",
     "typ": "JWT",
-    "url": "https://stepca:33067/acme/wire/challenge/VZ9OvDd8uCSXMXjXVMfQg63TLUnxGZKk/x0gGlwzcz1VJWjgD9dM5RIuoSsLU4yva"
+    "url": "https://stepca:32787/acme/wire/challenge/VRaT4cBr1eYvRHzU2nXAyT2pUgzUc9ES/vrVPmwGhchmsuKJffwy0NASsR643ivxB"
   }
 }
 ```
@@ -463,29 +462,29 @@ content-type: application/jose+json
 200
 cache-control: no-store
 content-type: application/json
-link: <https://stepca:33067/acme/wire/directory>;rel="index"
-link: <https://stepca:33067/acme/wire/authz/VZ9OvDd8uCSXMXjXVMfQg63TLUnxGZKk>;rel="up"
-location: https://stepca:33067/acme/wire/challenge/VZ9OvDd8uCSXMXjXVMfQg63TLUnxGZKk/x0gGlwzcz1VJWjgD9dM5RIuoSsLU4yva
-replay-nonce: UG13amx5bllYbDAwaTZLM0prYkJvelduUTBhWU5UMDI
+link: <https://stepca:32787/acme/wire/directory>;rel="index"
+link: <https://stepca:32787/acme/wire/authz/VRaT4cBr1eYvRHzU2nXAyT2pUgzUc9ES>;rel="up"
+location: https://stepca:32787/acme/wire/challenge/VRaT4cBr1eYvRHzU2nXAyT2pUgzUc9ES/vrVPmwGhchmsuKJffwy0NASsR643ivxB
+replay-nonce: MXJkSWIyUFZiN09zUXlYajNYZWNnVHVDYzY4b1NBbjg
 ```
 ```json
 {
   "type": "wire-dpop-01",
-  "url": "https://stepca:33067/acme/wire/challenge/VZ9OvDd8uCSXMXjXVMfQg63TLUnxGZKk/x0gGlwzcz1VJWjgD9dM5RIuoSsLU4yva",
+  "url": "https://stepca:32787/acme/wire/challenge/VRaT4cBr1eYvRHzU2nXAyT2pUgzUc9ES/vrVPmwGhchmsuKJffwy0NASsR643ivxB",
   "status": "valid",
-  "token": "84ShBugQ6MiMBPEjjLAxAUklhAzKubGS",
-  "target": "http://wire.com:15602/clients/a661e79735dc890f/access-token"
+  "token": "PmPL5ifCHeBvoeGTj7idCieaCkONv9Bh",
+  "target": "http://wire.com:23176/clients/ef6a91a91d3337a/access-token"
 }
 ```
 ### Authenticate end user using OIDC Authorization Code with PKCE flow
 #### 18. OAUTH authorization request
 
 ```text
-code_verifier=-LWuyIxVRDtctIbLnMJU0I3uN9723MDOURIhkFHGUD4&code_challenge=nzD__-6myeq8ShAEvsjkmh6Qk1FmkUolTJFetToAkTs
+code_verifier=S_pTcgu7by-I6OxS1TFMD0OilR485CCm_g3a38_QMTY&code_challenge=cMnU2uuUpSJ0mef4MADqwRE8B9RmxO0jgqe1GVD1IFc
 ```
 #### 19. OAUTH authorization request (auth code endpoint)
 ```http request
-GET http://dex:16070/dex/auth?response_type=code&client_id=wireapp&state=9KuC_GM616SsF47NJGOUkw&code_challenge=nzD__-6myeq8ShAEvsjkmh6Qk1FmkUolTJFetToAkTs&code_challenge_method=S256&redirect_uri=http%3A%2F%2Fwire.com%3A15602%2Fcallback&scope=openid+profile&nonce=xDWdABJLNZpYeeiU3q2eZA
+GET http://dex:16002/dex/auth?response_type=code&client_id=wireapp&state=Tp-IjfQECeLyMqzEGGYYVQ&code_challenge=cMnU2uuUpSJ0mef4MADqwRE8B9RmxO0jgqe1GVD1IFc&code_challenge_method=S256&redirect_uri=http%3A%2F%2Fwire.com%3A23176%2Fcallback&scope=openid+profile&nonce=VF-FNsxNvIl1kEJQzZ-Fwg
 ```
 
 #### 20. OAUTH authorization code
@@ -493,51 +492,51 @@ GET http://dex:16070/dex/auth?response_type=code&client_id=wireapp&state=9KuC_GM
 
 #### 22. OAUTH authorization code + verifier (token endpoint)
 ```http request
-POST http://dex:16070/dex/token
+POST http://dex:16002/dex/token
 accept: application/json
 content-type: application/x-www-form-urlencoded
-authorization: Basic d2lyZWFwcDphM1pHVlc5MWJVZDJkSHBYYlhkMFMwTlpSVGx4YWpGRw==
+authorization: Basic d2lyZWFwcDplREU1UmswMGRUWlhhVUpVY3pSR2FrSjJiRWg0Y0hoMw==
 ```
 ```text
-grant_type=authorization_code&code=q5jfcbhe2llgulvxi2los4dih&code_verifier=-LWuyIxVRDtctIbLnMJU0I3uN9723MDOURIhkFHGUD4&redirect_uri=http%3A%2F%2Fwire.com%3A15602%2Fcallback
+grant_type=authorization_code&code=bdhe7tori6nleufaypfepyts3&code_verifier=S_pTcgu7by-I6OxS1TFMD0OilR485CCm_g3a38_QMTY&redirect_uri=http%3A%2F%2Fwire.com%3A23176%2Fcallback
 ```
 #### 23. OAUTH access token
 
 ```text
 {
-  "access_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjBlYmI0ZGE4Zjg1ZDJmMzBmNTIzMDk4YzRiMGFlZTMzMmM3ZGU3ZTQifQ.eyJpc3MiOiJodHRwOi8vZGV4OjE2MDcwL2RleCIsInN1YiI6IkNsQnBiVHAzYVhKbFlYQndQVTFIUlhoT1ZFRXlUVVJPYVUxdFVUVk9SR1JvVG0xS2JVNUhSbXBPUjBwc1RsUkJNazFFV1hoT2JVMHZZVFkyTVdVM09UY3pOV1JqT0Rrd1prQjNhWEpsTG1OdmJSSUViR1JoY0EiLCJhdWQiOiJ3aXJlYXBwIiwiZXhwIjoxNjg2MTM5Njk4LCJpYXQiOjE2ODYwNTMyOTgsIm5vbmNlIjoieERXZEFCSkxOWnBZZWVpVTNxMmVaQSIsImF0X2hhc2giOiJVWC1Kc054QUxfVnp1MFViRUdUbDBBIiwibmFtZSI6ImltOndpcmVhcHA9YWxpY2Vfd2lyZSIsInByZWZlcnJlZF91c2VybmFtZSI6IkFsaWNlIFNtaXRoIn0.CGvt_CT8acCHx4l5AdKMqJLh12UtsjKWkKzn4qY8BfcAbfkiKGVjK_LuFAgpUySNKsa4skzcu3gC9VItOC_JXpQuXdz9XOEYaAKbGGN2R8BpA99skLOUp6fqToPlWYiAYULVcDjYxR92SIEyKjZoKDkMNGhlg-NZ7KVjYut129CU5n8ypWsILbw84sCBVg3eEbfTaJpBO3aXbGck5bZ5H8Bry8JWoSnA609wmSEqlmOn2pa9SqCgx8UhIxDxbD24MNaqj8-CK_V-zwa_pFQpP7ToZ3zKC3FtFsd0IyvN-6oKpCwtzG24yKEqtmw_mGu8Ihk0aredM8XmhGMF5yRegQ",
+  "access_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjQ3OGFiYmZkZTVkYmE2ZjJkNDI4YWZmNDVmODA0YzAyZDE0YTFlYjkifQ.eyJpc3MiOiJodHRwOi8vZGV4OjE2MDAyL2RleCIsInN1YiI6IkNrOXBiVHAzYVhKbFlYQndQVTVxV1ROT1ZGWm9Ua2RaZWsxNlJUUk9SMFpxVFVSbmVVOUhVVFZhVkZwb1QwZE5NMDU2V1hoT1ZFa3ZaV1kyWVRreFlUa3haRE16TXpkaFFIZHBjbVV1WTI5dEVnUnNaR0Z3IiwiYXVkIjoid2lyZWFwcCIsImV4cCI6MTY5MDg4MjA3MiwiaWF0IjoxNjkwNzk1NjcyLCJub25jZSI6IlZGLUZOc3hOdklsMWtFSlF6Wi1Gd2ciLCJhdF9oYXNoIjoiRnEzaEJkTDRTSFlsWVBMMHRvNU52dyIsIm5hbWUiOiJpbTp3aXJlYXBwPWFsaWNlX3dpcmUiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJBbGljZSBTbWl0aCJ9.NNBlGkzKo5FtRkMpSXMSZbf4qV5zar_WdJQbFqmbwU-apEGzrgSOifHx_hYYIda6SnggwmESPJt6JZbsXys0_bcm72wAGGkOxPUcSNlJ0JQHK-dtS2ITJpmQn4HClM6m_CQh-Y5Rb9MzuOkE5_7niom8L2LyCT7Z7YT7LfwZsjVE40bEviJmNlUfHmPIN0c5FPILY2HfqJ1iHx0VnFic9r9Leld3bRQVqEFiaq2ZXJGGUfoGjr_kZLyfswLkbQe8D0ra285uI_QE2tBn8a_ooJW7CTpNvXKDjySu7fQfW8s34jUV0hA_XtLfXUtwdlwMvdJ_u65yP-FNOQXZDQ6tXA",
   "expires_in": 86399,
-  "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjBlYmI0ZGE4Zjg1ZDJmMzBmNTIzMDk4YzRiMGFlZTMzMmM3ZGU3ZTQifQ.eyJpc3MiOiJodHRwOi8vZGV4OjE2MDcwL2RleCIsInN1YiI6IkNsQnBiVHAzYVhKbFlYQndQVTFIUlhoT1ZFRXlUVVJPYVUxdFVUVk9SR1JvVG0xS2JVNUhSbXBPUjBwc1RsUkJNazFFV1hoT2JVMHZZVFkyTVdVM09UY3pOV1JqT0Rrd1prQjNhWEpsTG1OdmJSSUViR1JoY0EiLCJhdWQiOiJ3aXJlYXBwIiwiZXhwIjoxNjg2MTM5Njk4LCJpYXQiOjE2ODYwNTMyOTgsIm5vbmNlIjoieERXZEFCSkxOWnBZZWVpVTNxMmVaQSIsImF0X2hhc2giOiJJNU1uQzRnd0xUaUxtaWl5eDlHcDVRIiwiY19oYXNoIjoiaDU2cldiZEpETVV1Rngzc2ZYX25BQSIsIm5hbWUiOiJpbTp3aXJlYXBwPWFsaWNlX3dpcmUiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJBbGljZSBTbWl0aCJ9.Pzc3V6DiR6b6cHPhFTAd08mdbWn5cUFkfNDOnA5vsTZXhjDEdu2_-loYzp5K7szLi_0pbSatGbD-2wtrxh6p3n9RP_m476hhJ-mtRWd3JhqoYCAguXoPK_FU1OCrdWQ81k1yg1MZLH5L6m3_mp3-asqzRIdljADxrf8O5Hygy7KiD5qDMW9kX5oZPxm__aQRmZ5jBgDqMlN4Nh1Bmnu6oQnlbFizqOwZ-dmo-LrlR4PtupApDuMJpylTTHIMfY6n7yxNUdGM5JiPnwZBT4UoHlC_lkfSomGV1MlhS2-yLTGAZHXgeM_Y0gtbzjwKYsB3ZlrXBqLiAmK4yweGus70uw",
+  "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjQ3OGFiYmZkZTVkYmE2ZjJkNDI4YWZmNDVmODA0YzAyZDE0YTFlYjkifQ.eyJpc3MiOiJodHRwOi8vZGV4OjE2MDAyL2RleCIsInN1YiI6IkNrOXBiVHAzYVhKbFlYQndQVTVxV1ROT1ZGWm9Ua2RaZWsxNlJUUk9SMFpxVFVSbmVVOUhVVFZhVkZwb1QwZE5NMDU2V1hoT1ZFa3ZaV1kyWVRreFlUa3haRE16TXpkaFFIZHBjbVV1WTI5dEVnUnNaR0Z3IiwiYXVkIjoid2lyZWFwcCIsImV4cCI6MTY5MDg4MjA3MiwiaWF0IjoxNjkwNzk1NjcyLCJub25jZSI6IlZGLUZOc3hOdklsMWtFSlF6Wi1Gd2ciLCJhdF9oYXNoIjoiWUNxZXJac3pCZlhkS2RHaktUX1YtUSIsImNfaGFzaCI6IlZVMkRUX1ZRMjU1dVZzajZwNExwVGciLCJuYW1lIjoiaW06d2lyZWFwcD1hbGljZV93aXJlIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiQWxpY2UgU21pdGgifQ.CULrJ14yGoeJOJY7am5rqXjYoQ7i9Ka8VtgVvODHm5IszHfq7sJvPoBH2hFZrZ8Re1fXU5cli55skDxksOIlUooMyGQuqM8bvwz7NoOSJx4njENBYRqYosUVllT1ugWleGhTjZrTw5tPy2TifSWSVXmjk2R0lRcF-yOv3YWRJtPnOgRiQIi50GzvfZlZgepCxyAJsNpqyYfmCdZFBfFVOZKLU19jfV-BCE9S5JiGgwNdgMtKmo9s0oJKtXHe4zh4RqdeSSM4MhkkgM9EuKwq0t8wRG2hpTJQ6dT-54rrXF5zrg3KbFi9wB0QwO3Nuxatp_55dKjjC29xkqXHD4Z9Ag",
   "token_type": "bearer"
 }
 ```
 ```text
-eyJhbGciOiJSUzI1NiIsImtpZCI6IjBlYmI0ZGE4Zjg1ZDJmMzBmNTIzMDk4YzRiMGFlZTMzMmM3ZGU3ZTQifQ.eyJpc3MiOiJodHRwOi8vZGV4OjE2MDcwL2RleCIsInN1YiI6IkNsQnBiVHAzYVhKbFlYQndQVTFIUlhoT1ZFRXlUVVJPYVUxdFVUVk9SR1JvVG0xS2JVNUhSbXBPUjBwc1RsUkJNazFFV1hoT2JVMHZZVFkyTVdVM09UY3pOV1JqT0Rrd1prQjNhWEpsTG1OdmJSSUViR1JoY0EiLCJhdWQiOiJ3aXJlYXBwIiwiZXhwIjoxNjg2MTM5Njk4LCJpYXQiOjE2ODYwNTMyOTgsIm5vbmNlIjoieERXZEFCSkxOWnBZZWVpVTNxMmVaQSIsImF0X2hhc2giOiJJNU1uQzRnd0xUaUxtaWl5eDlHcDVRIiwiY19oYXNoIjoiaDU2cldiZEpETVV1Rngzc2ZYX25BQSIsIm5hbWUiOiJpbTp3aXJlYXBwPWFsaWNlX3dpcmUiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJBbGljZSBTbWl0aCJ9.Pzc3V6DiR6b6cHPhFTAd08mdbWn5cUFkfNDOnA5vsTZXhjDEdu2_-loYzp5K7szLi_0pbSatGbD-2wtrxh6p3n9RP_m476hhJ-mtRWd3JhqoYCAguXoPK_FU1OCrdWQ81k1yg1MZLH5L6m3_mp3-asqzRIdljADxrf8O5Hygy7KiD5qDMW9kX5oZPxm__aQRmZ5jBgDqMlN4Nh1Bmnu6oQnlbFizqOwZ-dmo-LrlR4PtupApDuMJpylTTHIMfY6n7yxNUdGM5JiPnwZBT4UoHlC_lkfSomGV1MlhS2-yLTGAZHXgeM_Y0gtbzjwKYsB3ZlrXBqLiAmK4yweGus70uw
+eyJhbGciOiJSUzI1NiIsImtpZCI6IjQ3OGFiYmZkZTVkYmE2ZjJkNDI4YWZmNDVmODA0YzAyZDE0YTFlYjkifQ.eyJpc3MiOiJodHRwOi8vZGV4OjE2MDAyL2RleCIsInN1YiI6IkNrOXBiVHAzYVhKbFlYQndQVTVxV1ROT1ZGWm9Ua2RaZWsxNlJUUk9SMFpxVFVSbmVVOUhVVFZhVkZwb1QwZE5NMDU2V1hoT1ZFa3ZaV1kyWVRreFlUa3haRE16TXpkaFFIZHBjbVV1WTI5dEVnUnNaR0Z3IiwiYXVkIjoid2lyZWFwcCIsImV4cCI6MTY5MDg4MjA3MiwiaWF0IjoxNjkwNzk1NjcyLCJub25jZSI6IlZGLUZOc3hOdklsMWtFSlF6Wi1Gd2ciLCJhdF9oYXNoIjoiWUNxZXJac3pCZlhkS2RHaktUX1YtUSIsImNfaGFzaCI6IlZVMkRUX1ZRMjU1dVZzajZwNExwVGciLCJuYW1lIjoiaW06d2lyZWFwcD1hbGljZV93aXJlIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiQWxpY2UgU21pdGgifQ.CULrJ14yGoeJOJY7am5rqXjYoQ7i9Ka8VtgVvODHm5IszHfq7sJvPoBH2hFZrZ8Re1fXU5cli55skDxksOIlUooMyGQuqM8bvwz7NoOSJx4njENBYRqYosUVllT1ugWleGhTjZrTw5tPy2TifSWSVXmjk2R0lRcF-yOv3YWRJtPnOgRiQIi50GzvfZlZgepCxyAJsNpqyYfmCdZFBfFVOZKLU19jfV-BCE9S5JiGgwNdgMtKmo9s0oJKtXHe4zh4RqdeSSM4MhkkgM9EuKwq0t8wRG2hpTJQ6dT-54rrXF5zrg3KbFi9wB0QwO3Nuxatp_55dKjjC29xkqXHD4Z9Ag
 ```
 #### 24. validate oidc challenge (userId + displayName)
 
 <details>
 <summary><b>Id token</b></summary>
 
-See it on [jwt.io](https://jwt.io/#id_token=eyJhbGciOiJSUzI1NiIsImtpZCI6IjBlYmI0ZGE4Zjg1ZDJmMzBmNTIzMDk4YzRiMGFlZTMzMmM3ZGU3ZTQifQ.eyJpc3MiOiJodHRwOi8vZGV4OjE2MDcwL2RleCIsInN1YiI6IkNsQnBiVHAzYVhKbFlYQndQVTFIUlhoT1ZFRXlUVVJPYVUxdFVUVk9SR1JvVG0xS2JVNUhSbXBPUjBwc1RsUkJNazFFV1hoT2JVMHZZVFkyTVdVM09UY3pOV1JqT0Rrd1prQjNhWEpsTG1OdmJSSUViR1JoY0EiLCJhdWQiOiJ3aXJlYXBwIiwiZXhwIjoxNjg2MTM5Njk4LCJpYXQiOjE2ODYwNTMyOTgsIm5vbmNlIjoieERXZEFCSkxOWnBZZWVpVTNxMmVaQSIsImF0X2hhc2giOiJJNU1uQzRnd0xUaUxtaWl5eDlHcDVRIiwiY19oYXNoIjoiaDU2cldiZEpETVV1Rngzc2ZYX25BQSIsIm5hbWUiOiJpbTp3aXJlYXBwPWFsaWNlX3dpcmUiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJBbGljZSBTbWl0aCJ9.Pzc3V6DiR6b6cHPhFTAd08mdbWn5cUFkfNDOnA5vsTZXhjDEdu2_-loYzp5K7szLi_0pbSatGbD-2wtrxh6p3n9RP_m476hhJ-mtRWd3JhqoYCAguXoPK_FU1OCrdWQ81k1yg1MZLH5L6m3_mp3-asqzRIdljADxrf8O5Hygy7KiD5qDMW9kX5oZPxm__aQRmZ5jBgDqMlN4Nh1Bmnu6oQnlbFizqOwZ-dmo-LrlR4PtupApDuMJpylTTHIMfY6n7yxNUdGM5JiPnwZBT4UoHlC_lkfSomGV1MlhS2-yLTGAZHXgeM_Y0gtbzjwKYsB3ZlrXBqLiAmK4yweGus70uw)
+See it on [jwt.io](https://jwt.io/#id_token=eyJhbGciOiJSUzI1NiIsImtpZCI6IjQ3OGFiYmZkZTVkYmE2ZjJkNDI4YWZmNDVmODA0YzAyZDE0YTFlYjkifQ.eyJpc3MiOiJodHRwOi8vZGV4OjE2MDAyL2RleCIsInN1YiI6IkNrOXBiVHAzYVhKbFlYQndQVTVxV1ROT1ZGWm9Ua2RaZWsxNlJUUk9SMFpxVFVSbmVVOUhVVFZhVkZwb1QwZE5NMDU2V1hoT1ZFa3ZaV1kyWVRreFlUa3haRE16TXpkaFFIZHBjbVV1WTI5dEVnUnNaR0Z3IiwiYXVkIjoid2lyZWFwcCIsImV4cCI6MTY5MDg4MjA3MiwiaWF0IjoxNjkwNzk1NjcyLCJub25jZSI6IlZGLUZOc3hOdklsMWtFSlF6Wi1Gd2ciLCJhdF9oYXNoIjoiWUNxZXJac3pCZlhkS2RHaktUX1YtUSIsImNfaGFzaCI6IlZVMkRUX1ZRMjU1dVZzajZwNExwVGciLCJuYW1lIjoiaW06d2lyZWFwcD1hbGljZV93aXJlIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiQWxpY2UgU21pdGgifQ.CULrJ14yGoeJOJY7am5rqXjYoQ7i9Ka8VtgVvODHm5IszHfq7sJvPoBH2hFZrZ8Re1fXU5cli55skDxksOIlUooMyGQuqM8bvwz7NoOSJx4njENBYRqYosUVllT1ugWleGhTjZrTw5tPy2TifSWSVXmjk2R0lRcF-yOv3YWRJtPnOgRiQIi50GzvfZlZgepCxyAJsNpqyYfmCdZFBfFVOZKLU19jfV-BCE9S5JiGgwNdgMtKmo9s0oJKtXHe4zh4RqdeSSM4MhkkgM9EuKwq0t8wRG2hpTJQ6dT-54rrXF5zrg3KbFi9wB0QwO3Nuxatp_55dKjjC29xkqXHD4Z9Ag)
 
 Raw:
 ```text
-eyJhbGciOiJSUzI1NiIsImtpZCI6IjBlYmI0ZGE4Zjg1ZDJmMzBmNTIzMDk4YzRi
-MGFlZTMzMmM3ZGU3ZTQifQ.eyJpc3MiOiJodHRwOi8vZGV4OjE2MDcwL2RleCIsI
-nN1YiI6IkNsQnBiVHAzYVhKbFlYQndQVTFIUlhoT1ZFRXlUVVJPYVUxdFVUVk9SR
-1JvVG0xS2JVNUhSbXBPUjBwc1RsUkJNazFFV1hoT2JVMHZZVFkyTVdVM09UY3pOV
-1JqT0Rrd1prQjNhWEpsTG1OdmJSSUViR1JoY0EiLCJhdWQiOiJ3aXJlYXBwIiwiZ
-XhwIjoxNjg2MTM5Njk4LCJpYXQiOjE2ODYwNTMyOTgsIm5vbmNlIjoieERXZEFCS
-kxOWnBZZWVpVTNxMmVaQSIsImF0X2hhc2giOiJJNU1uQzRnd0xUaUxtaWl5eDlHc
-DVRIiwiY19oYXNoIjoiaDU2cldiZEpETVV1Rngzc2ZYX25BQSIsIm5hbWUiOiJpb
-Tp3aXJlYXBwPWFsaWNlX3dpcmUiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJBbGljZ
-SBTbWl0aCJ9.Pzc3V6DiR6b6cHPhFTAd08mdbWn5cUFkfNDOnA5vsTZXhjDEdu2_
--loYzp5K7szLi_0pbSatGbD-2wtrxh6p3n9RP_m476hhJ-mtRWd3JhqoYCAguXoP
-K_FU1OCrdWQ81k1yg1MZLH5L6m3_mp3-asqzRIdljADxrf8O5Hygy7KiD5qDMW9k
-X5oZPxm__aQRmZ5jBgDqMlN4Nh1Bmnu6oQnlbFizqOwZ-dmo-LrlR4PtupApDuMJ
-pylTTHIMfY6n7yxNUdGM5JiPnwZBT4UoHlC_lkfSomGV1MlhS2-yLTGAZHXgeM_Y
-0gtbzjwKYsB3ZlrXBqLiAmK4yweGus70uw
+eyJhbGciOiJSUzI1NiIsImtpZCI6IjQ3OGFiYmZkZTVkYmE2ZjJkNDI4YWZmNDVm
+ODA0YzAyZDE0YTFlYjkifQ.eyJpc3MiOiJodHRwOi8vZGV4OjE2MDAyL2RleCIsI
+nN1YiI6IkNrOXBiVHAzYVhKbFlYQndQVTVxV1ROT1ZGWm9Ua2RaZWsxNlJUUk9SM
+FpxVFVSbmVVOUhVVFZhVkZwb1QwZE5NMDU2V1hoT1ZFa3ZaV1kyWVRreFlUa3haR
+E16TXpkaFFIZHBjbVV1WTI5dEVnUnNaR0Z3IiwiYXVkIjoid2lyZWFwcCIsImV4c
+CI6MTY5MDg4MjA3MiwiaWF0IjoxNjkwNzk1NjcyLCJub25jZSI6IlZGLUZOc3hOd
+klsMWtFSlF6Wi1Gd2ciLCJhdF9oYXNoIjoiWUNxZXJac3pCZlhkS2RHaktUX1YtU
+SIsImNfaGFzaCI6IlZVMkRUX1ZRMjU1dVZzajZwNExwVGciLCJuYW1lIjoiaW06d
+2lyZWFwcD1hbGljZV93aXJlIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiQWxpY2UgU
+21pdGgifQ.CULrJ14yGoeJOJY7am5rqXjYoQ7i9Ka8VtgVvODHm5IszHfq7sJvPo
+BH2hFZrZ8Re1fXU5cli55skDxksOIlUooMyGQuqM8bvwz7NoOSJx4njENBYRqYos
+UVllT1ugWleGhTjZrTw5tPy2TifSWSVXmjk2R0lRcF-yOv3YWRJtPnOgRiQIi50G
+zvfZlZgepCxyAJsNpqyYfmCdZFBfFVOZKLU19jfV-BCE9S5JiGgwNdgMtKmo9s0o
+JKtXHe4zh4RqdeSSM4MhkkgM9EuKwq0t8wRG2hpTJQ6dT-54rrXF5zrg3KbFi9wB
+0QwO3Nuxatp_55dKjjC29xkqXHD4Z9Ag
 ```
 
 Decoded:
@@ -545,22 +544,22 @@ Decoded:
 ```json
 {
   "alg": "RS256",
-  "kid": "0ebb4da8f85d2f30f523098c4b0aee332c7de7e4"
+  "kid": "478abbfde5dba6f2d428aff45f804c02d14a1eb9"
 }
 ```
 
 ```json
 {
-  "at_hash": "I5MnC4gwLTiLmiiyx9Gp5Q",
+  "at_hash": "YCqerZszBfXdKdGjKT_V-Q",
   "aud": "wireapp",
-  "c_hash": "h56rWbdJDMUuFx3sfX_nAA",
-  "exp": 1686139698,
-  "iat": 1686053298,
-  "iss": "http://dex:16070/dex",
+  "c_hash": "VU2DT_VQ255uVsj6p4LpTg",
+  "exp": 1690882072,
+  "iat": 1690795672,
+  "iss": "http://dex:16002/dex",
   "name": "im:wireapp=alice_wire",
-  "nonce": "xDWdABJLNZpYeeiU3q2eZA",
+  "nonce": "VF-FNsxNvIl1kEJQzZ-Fwg",
   "preferred_username": "Alice Smith",
-  "sub": "ClBpbTp3aXJlYXBwPU1HRXhOVEEyTUROaU1tUTVORGRoTm1KbU5HRmpOR0psTlRBMk1EWXhObU0vYTY2MWU3OTczNWRjODkwZkB3aXJlLmNvbRIEbGRhcA"
+  "sub": "Ck9pbTp3aXJlYXBwPU5qWTNOVFZoTkdZek16RTROR0ZqTURneU9HUTVaVFpoT0dNM056WXhOVEkvZWY2YTkxYTkxZDMzMzdhQHdpcmUuY29tEgRsZGFw"
 }
 ```
 
@@ -568,13 +567,13 @@ Decoded:
 ✅ Signature Verified with key:
 ```text
 -----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAthtsqOR/txR4VGaaWSJ7
-enfAhfNIDxfn6FEy/djxUxi6BF1pQuNumIgSk3mD9dLb7flCYTLPI59U+pFeoqA/
-qj817l6Hyl3D1BWI3b7Z9/fcXG/1Vc5xf2hNAvxKIX41ls9ZjSADplJce7sA5dcy
-nTzjnN2ufe7mA0O98aKewKC1t0lNrBmeKtziau0dpirW2a9Mr3rOPrca4aI3rGUy
-jiq+QcZSfsdxfD3rdJng7iC4vAkgixW6cN90/zk/C+GAOM2qOcGsKc7O1Ij0+xtI
-aJLynpm6M25EpFFo4X9mC2eVc9pB83rwTW1XzjmZ2gM5idEtDYoq9WYDgqF0iXkl
-6wIDAQAB
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7lT4uYG5Iae9FvxQ4oPW
+N4uD06dT+tCYenEUZyTTXQBobolqbuf21ggWDBx9Mh7u8nFD3cdGF/gmVaJnxHQA
+bAdr48R0Pv9hbd4RGNrYiiR1rmyB7Dp4kpdn1Jwvdlwxrr8jNPMOQ7LhFO31I3DK
+9YykHuFPKP/3YEbb3Ek3OvprsCpZbJ6FJcj9QkBAULwLIshMytLY5y+vWtq+wICg
+2rYMFcCYPNbBD8TjfWq1vWsFIyjXbGqWXMLq7r+crdi9QHrPYD/aQ4dZGweV+FCa
+EWLvQVLNJSO4G8bgonuokj92A1//+4jN5xqqbreokygSYTOSOVbR+qooGLb0nm+O
+cwIDAQAB
 -----END PUBLIC KEY-----
 ```
 
@@ -583,29 +582,29 @@ aJLynpm6M25EpFFo4X9mC2eVc9pB83rwTW1XzjmZ2gM5idEtDYoq9WYDgqF0iXkl
 
 Note: The ACME provisioner is configured with rules for transforming values received in the token into a Wire handle and display name.
 ```http request
-POST https://stepca:33067/acme/wire/challenge/VZ9OvDd8uCSXMXjXVMfQg63TLUnxGZKk/Zaa3kx1T7ThIuYBI4KiS4dmBWetKeXNW
+POST https://stepca:32787/acme/wire/challenge/VRaT4cBr1eYvRHzU2nXAyT2pUgzUc9ES/n5FFoVwi6IonK80GtLFgpG18ZoKEXoqQ
                          /acme/{acme-provisioner}/challenge/{authz-id}/{challenge-id}
 content-type: application/jose+json
 ```
 ```json
 {
-  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMzMDY3L2FjbWUvd2lyZS9hY2NvdW50LzNmOFAyQTMzeEFNVFVWbk5MSlRaZUhUQ2p3MDhXeHU2IiwidHlwIjoiSldUIiwibm9uY2UiOiJVRzEzYW14NWJsbFliREF3YVRaTE0wcHJZa0p2ZWxkdVVUQmhXVTVVTURJIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzMwNjcvYWNtZS93aXJlL2NoYWxsZW5nZS9WWjlPdkRkOHVDU1hNWGpYVk1mUWc2M1RMVW54R1pLay9aYWEza3gxVDdUaEl1WUJJNEtpUzRkbUJXZXRLZVhOVyJ9",
-  "payload": "eyJpZF90b2tlbiI6ImV5SmhiR2NpT2lKU1V6STFOaUlzSW10cFpDSTZJakJsWW1JMFpHRTRaamcxWkRKbU16Qm1OVEl6TURrNFl6UmlNR0ZsWlRNek1tTTNaR1UzWlRRaWZRLmV5SnBjM01pT2lKb2RIUndPaTh2WkdWNE9qRTJNRGN3TDJSbGVDSXNJbk4xWWlJNklrTnNRbkJpVkhBellWaEtiRmxZUW5kUVZURklVbGhvVDFaRlJYbFVWVkpQWVZVeGRGVlVWazlTUjFKdlZHMHhTMkpWTlVoU2JYQlBVakJ3YzFSc1VrSk5hekZGVjFob1QySlZNSFpaVkZreVRWZFZNMDlVWTNwT1YxSnFUMFJyZDFwclFqTmhXRXBzVEcxT2RtSlNTVVZpUjFKb1kwRWlMQ0poZFdRaU9pSjNhWEpsWVhCd0lpd2laWGh3SWpveE5qZzJNVE01TmprNExDSnBZWFFpT2pFMk9EWXdOVE15T1Rnc0ltNXZibU5sSWpvaWVFUlhaRUZDU2t4T1duQlpaV1ZwVlROeE1tVmFRU0lzSW1GMFgyaGhjMmdpT2lKSk5VMXVRelJuZDB4VWFVeHRhV2w1ZURsSGNEVlJJaXdpWTE5b1lYTm9Jam9pYURVMmNsZGlaRXBFVFZWMVJuZ3pjMlpZWDI1QlFTSXNJbTVoYldVaU9pSnBiVHAzYVhKbFlYQndQV0ZzYVdObFgzZHBjbVVpTENKd2NtVm1aWEp5WldSZmRYTmxjbTVoYldVaU9pSkJiR2xqWlNCVGJXbDBhQ0o5LlB6YzNWNkRpUjZiNmNIUGhGVEFkMDhtZGJXbjVjVUZrZk5ET25BNXZzVFpYaGpERWR1Ml8tbG9ZenA1SzdzekxpXzBwYlNhdEdiRC0yd3RyeGg2cDNuOVJQX200NzZoaEotbXRSV2QzSmhxb1lDQWd1WG9QS19GVTFPQ3JkV1E4MWsxeWcxTVpMSDVMNm0zX21wMy1hc3F6UklkbGpBRHhyZjhPNUh5Z3k3S2lENXFETVc5a1g1b1pQeG1fX2FRUm1aNWpCZ0RxTWxONE5oMUJtbnU2b1FubGJGaXpxT3daLWRtby1McmxSNFB0dXBBcER1TUpweWxUVEhJTWZZNm43eXhOVWRHTTVKaVBud1pCVDRVb0hsQ19sa2ZTb21HVjFNbGhTMi15TFRHQVpIWGdlTV9ZMGd0Ynpqd0tZc0IzWmxyWEJxTGlBbUs0eXdlR3VzNzB1dyIsImtleWF1dGgiOiI4NFNoQnVnUTZNaU1CUEVqakxBeEFVa2xoQXpLdWJHUy5kZzE5Z05IeUN3VDQ3MjNoZGNZRWc0R1BqV0d0UzNKWDFEUHlqS2tNTU1vIn0",
-  "signature": "rTuVlCLkZpw-Ycd_vSh5V-5jkAV35D7rUkhCqwwCEgCIZDcT6yJKeo42lM5padHRqzviyISlLPCcmGBbS6VdDg"
+  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMyNzg3L2FjbWUvd2lyZS9hY2NvdW50L0lZRk5jNEEwYWVTcEhPVmFxT0wzNjZPb1ZOQlBVczFmIiwidHlwIjoiSldUIiwibm9uY2UiOiJNWEprU1dJeVVGWmlOMDl6VVhsWWFqTllaV05uVkhWRFl6WTRiMU5CYmpnIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI3ODcvYWNtZS93aXJlL2NoYWxsZW5nZS9WUmFUNGNCcjFlWXZSSHpVMm5YQXlUMnBVZ3pVYzlFUy9uNUZGb1Z3aTZJb25LODBHdExGZ3BHMThab0tFWG9xUSJ9",
+  "payload": "eyJpZF90b2tlbiI6ImV5SmhiR2NpT2lKU1V6STFOaUlzSW10cFpDSTZJalEzT0dGaVltWmtaVFZrWW1FMlpqSmtOREk0WVdabU5EVm1PREEwWXpBeVpERTBZVEZsWWpraWZRLmV5SnBjM01pT2lKb2RIUndPaTh2WkdWNE9qRTJNREF5TDJSbGVDSXNJbk4xWWlJNklrTnJPWEJpVkhBellWaEtiRmxZUW5kUVZUVnhWMVJPVDFaR1dtOVVhMlJhWldzeE5sSlVVazlTTUZweFZGVlNibVZWT1VoVlZGWmhWa1p3YjFRd1pFNU5NRFUyVjFob1QxWkZhM1phVjFreVdWUnJlRmxVYTNoYVJFMTZUWHBrYUZGSVpIQmpiVlYxV1RJNWRFVm5Vbk5hUjBaM0lpd2lZWFZrSWpvaWQybHlaV0Z3Y0NJc0ltVjRjQ0k2TVRZNU1EZzRNakEzTWl3aWFXRjBJam94Tmprd056azFOamN5TENKdWIyNWpaU0k2SWxaR0xVWk9jM2hPZGtsc01XdEZTbEY2V2kxR2QyY2lMQ0poZEY5b1lYTm9Jam9pV1VOeFpYSmFjM3BDWmxoa1MyUkhha3RVWDFZdFVTSXNJbU5mYUdGemFDSTZJbFpWTWtSVVgxWlJNalUxZFZaemFqWndORXh3VkdjaUxDSnVZVzFsSWpvaWFXMDZkMmx5WldGd2NEMWhiR2xqWlY5M2FYSmxJaXdpY0hKbFptVnljbVZrWDNWelpYSnVZVzFsSWpvaVFXeHBZMlVnVTIxcGRHZ2lmUS5DVUxySjE0eUdvZUpPSlk3YW01cnFYallvUTdpOUthOFZ0Z1Z2T0RIbTVJc3pIZnE3c0p2UG9CSDJoRlpyWjhSZTFmWFU1Y2xpNTVza0R4a3NPSWxVb29NeUdRdXFNOGJ2d3o3Tm9PU0p4NG5qRU5CWVJxWW9zVVZsbFQxdWdXbGVHaFRqWnJUdzV0UHkyVGlmU1dTVlhtamsyUjBsUmNGLXlPdjNZV1JKdFBuT2dSaVFJaTUwR3p2ZlpsWmdlcEN4eUFKc05wcXlZZm1DZFpGQmZGVk9aS0xVMTlqZlYtQkNFOVM1SmlHZ3dOZGdNdEttbzlzMG9KS3RYSGU0emg0UnFkZVNTTTRNaGtrZ005RXVLd3EwdDh3UkcyaHBUSlE2ZFQtNTRyclhGNXpyZzNLYkZpOXdCMFF3TzNOdXhhdHBfNTVkS2pqQzI5eGtxWEhENFo5QWciLCJrZXlhdXRoIjoiUG1QTDVpZkNIZUJ2b2VHVGo3aWRDaWVhQ2tPTnY5QmgudXlsTUhqb2U4RlpZSmFZUVFNUGJBQUNXTWc2UGFUNEFkQVF4OHRncGRvQSJ9",
+  "signature": "vJT1Qr1TYbaTcxz11k3aCNC7kjrpsLU4h-ZSY8XOYLE8kFkxbsAntmkyqO33edvMAmnQsDsBJAwJfXmLx8A0Cw"
 }
 ```
 ```json
 {
   "payload": {
-    "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjBlYmI0ZGE4Zjg1ZDJmMzBmNTIzMDk4YzRiMGFlZTMzMmM3ZGU3ZTQifQ.eyJpc3MiOiJodHRwOi8vZGV4OjE2MDcwL2RleCIsInN1YiI6IkNsQnBiVHAzYVhKbFlYQndQVTFIUlhoT1ZFRXlUVVJPYVUxdFVUVk9SR1JvVG0xS2JVNUhSbXBPUjBwc1RsUkJNazFFV1hoT2JVMHZZVFkyTVdVM09UY3pOV1JqT0Rrd1prQjNhWEpsTG1OdmJSSUViR1JoY0EiLCJhdWQiOiJ3aXJlYXBwIiwiZXhwIjoxNjg2MTM5Njk4LCJpYXQiOjE2ODYwNTMyOTgsIm5vbmNlIjoieERXZEFCSkxOWnBZZWVpVTNxMmVaQSIsImF0X2hhc2giOiJJNU1uQzRnd0xUaUxtaWl5eDlHcDVRIiwiY19oYXNoIjoiaDU2cldiZEpETVV1Rngzc2ZYX25BQSIsIm5hbWUiOiJpbTp3aXJlYXBwPWFsaWNlX3dpcmUiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJBbGljZSBTbWl0aCJ9.Pzc3V6DiR6b6cHPhFTAd08mdbWn5cUFkfNDOnA5vsTZXhjDEdu2_-loYzp5K7szLi_0pbSatGbD-2wtrxh6p3n9RP_m476hhJ-mtRWd3JhqoYCAguXoPK_FU1OCrdWQ81k1yg1MZLH5L6m3_mp3-asqzRIdljADxrf8O5Hygy7KiD5qDMW9kX5oZPxm__aQRmZ5jBgDqMlN4Nh1Bmnu6oQnlbFizqOwZ-dmo-LrlR4PtupApDuMJpylTTHIMfY6n7yxNUdGM5JiPnwZBT4UoHlC_lkfSomGV1MlhS2-yLTGAZHXgeM_Y0gtbzjwKYsB3ZlrXBqLiAmK4yweGus70uw",
-    "keyauth": "84ShBugQ6MiMBPEjjLAxAUklhAzKubGS.dg19gNHyCwT4723hdcYEg4GPjWGtS3JX1DPyjKkMMMo"
+    "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjQ3OGFiYmZkZTVkYmE2ZjJkNDI4YWZmNDVmODA0YzAyZDE0YTFlYjkifQ.eyJpc3MiOiJodHRwOi8vZGV4OjE2MDAyL2RleCIsInN1YiI6IkNrOXBiVHAzYVhKbFlYQndQVTVxV1ROT1ZGWm9Ua2RaZWsxNlJUUk9SMFpxVFVSbmVVOUhVVFZhVkZwb1QwZE5NMDU2V1hoT1ZFa3ZaV1kyWVRreFlUa3haRE16TXpkaFFIZHBjbVV1WTI5dEVnUnNaR0Z3IiwiYXVkIjoid2lyZWFwcCIsImV4cCI6MTY5MDg4MjA3MiwiaWF0IjoxNjkwNzk1NjcyLCJub25jZSI6IlZGLUZOc3hOdklsMWtFSlF6Wi1Gd2ciLCJhdF9oYXNoIjoiWUNxZXJac3pCZlhkS2RHaktUX1YtUSIsImNfaGFzaCI6IlZVMkRUX1ZRMjU1dVZzajZwNExwVGciLCJuYW1lIjoiaW06d2lyZWFwcD1hbGljZV93aXJlIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiQWxpY2UgU21pdGgifQ.CULrJ14yGoeJOJY7am5rqXjYoQ7i9Ka8VtgVvODHm5IszHfq7sJvPoBH2hFZrZ8Re1fXU5cli55skDxksOIlUooMyGQuqM8bvwz7NoOSJx4njENBYRqYosUVllT1ugWleGhTjZrTw5tPy2TifSWSVXmjk2R0lRcF-yOv3YWRJtPnOgRiQIi50GzvfZlZgepCxyAJsNpqyYfmCdZFBfFVOZKLU19jfV-BCE9S5JiGgwNdgMtKmo9s0oJKtXHe4zh4RqdeSSM4MhkkgM9EuKwq0t8wRG2hpTJQ6dT-54rrXF5zrg3KbFi9wB0QwO3Nuxatp_55dKjjC29xkqXHD4Z9Ag",
+    "keyauth": "PmPL5ifCHeBvoeGTj7idCieaCkONv9Bh.uylMHjoe8FZYJaYQQMPbAACWMg6PaT4AdAQx8tgpdoA"
   },
   "protected": {
     "alg": "EdDSA",
-    "kid": "https://stepca:33067/acme/wire/account/3f8P2A33xAMTUVnNLJTZeHTCjw08Wxu6",
-    "nonce": "UG13amx5bllYbDAwaTZLM0prYkJvelduUTBhWU5UMDI",
+    "kid": "https://stepca:32787/acme/wire/account/IYFNc4A0aeSpHOVaqOL366OoVNBPUs1f",
+    "nonce": "MXJkSWIyUFZiN09zUXlYajNYZWNnVHVDYzY4b1NBbjg",
     "typ": "JWT",
-    "url": "https://stepca:33067/acme/wire/challenge/VZ9OvDd8uCSXMXjXVMfQg63TLUnxGZKk/Zaa3kx1T7ThIuYBI4KiS4dmBWetKeXNW"
+    "url": "https://stepca:32787/acme/wire/challenge/VRaT4cBr1eYvRHzU2nXAyT2pUgzUc9ES/n5FFoVwi6IonK80GtLFgpG18ZoKEXoqQ"
   }
 }
 ```
@@ -614,32 +613,32 @@ content-type: application/jose+json
 200
 cache-control: no-store
 content-type: application/json
-link: <https://stepca:33067/acme/wire/directory>;rel="index"
-link: <https://stepca:33067/acme/wire/authz/VZ9OvDd8uCSXMXjXVMfQg63TLUnxGZKk>;rel="up"
-location: https://stepca:33067/acme/wire/challenge/VZ9OvDd8uCSXMXjXVMfQg63TLUnxGZKk/Zaa3kx1T7ThIuYBI4KiS4dmBWetKeXNW
-replay-nonce: ZEo4S1h6UmVVYVZMSUlNcEN0MERyaTdObmZUQ1dwWUE
+link: <https://stepca:32787/acme/wire/directory>;rel="index"
+link: <https://stepca:32787/acme/wire/authz/VRaT4cBr1eYvRHzU2nXAyT2pUgzUc9ES>;rel="up"
+location: https://stepca:32787/acme/wire/challenge/VRaT4cBr1eYvRHzU2nXAyT2pUgzUc9ES/n5FFoVwi6IonK80GtLFgpG18ZoKEXoqQ
+replay-nonce: bUxONUhqOHhFVERFam1YYTVQSm1YYXpNVVRyb3N1dlY
 ```
 ```json
 {
   "type": "wire-oidc-01",
-  "url": "https://stepca:33067/acme/wire/challenge/VZ9OvDd8uCSXMXjXVMfQg63TLUnxGZKk/Zaa3kx1T7ThIuYBI4KiS4dmBWetKeXNW",
+  "url": "https://stepca:32787/acme/wire/challenge/VRaT4cBr1eYvRHzU2nXAyT2pUgzUc9ES/n5FFoVwi6IonK80GtLFgpG18ZoKEXoqQ",
   "status": "valid",
-  "token": "84ShBugQ6MiMBPEjjLAxAUklhAzKubGS",
-  "target": "http://dex:16070/dex"
+  "token": "PmPL5ifCHeBvoeGTj7idCieaCkONv9Bh",
+  "target": "http://dex:16002/dex"
 }
 ```
 ### Client presents a CSR and gets its certificate
 #### 26. verify the status of the order
 ```http request
-POST https://stepca:33067/acme/wire/order/D71zUASw1bMHdxcv5z7ZEZPpiImVQo8I
+POST https://stepca:32787/acme/wire/order/NyuMpBEdChjI5wo4EJEFQOjvb63X68NZ
                          /acme/{acme-provisioner}/order/{order-id}
 content-type: application/jose+json
 ```
 ```json
 {
-  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMzMDY3L2FjbWUvd2lyZS9hY2NvdW50LzNmOFAyQTMzeEFNVFVWbk5MSlRaZUhUQ2p3MDhXeHU2IiwidHlwIjoiSldUIiwibm9uY2UiOiJaRW80UzFoNlVtVlZZVlpNU1VsTmNFTjBNRVJ5YVRkT2JtWlVRMWR3V1VFIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzMwNjcvYWNtZS93aXJlL29yZGVyL0Q3MXpVQVN3MWJNSGR4Y3Y1ejdaRVpQcGlJbVZRbzhJIn0",
+  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMyNzg3L2FjbWUvd2lyZS9hY2NvdW50L0lZRk5jNEEwYWVTcEhPVmFxT0wzNjZPb1ZOQlBVczFmIiwidHlwIjoiSldUIiwibm9uY2UiOiJiVXhPTlVocU9IaEZWRVJGYW0xWVlUVlFTbTFZWVhwTlZWUnliM04xZGxZIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI3ODcvYWNtZS93aXJlL29yZGVyL055dU1wQkVkQ2hqSTV3bzRFSkVGUU9qdmI2M1g2OE5aIn0",
   "payload": "",
-  "signature": "tqfUopbWQ4nd_3cYk7K36_2pZh57fob9kPulsgHnUsRCFPThesL6XzM9_vSN-WsUvIl4xuHhCsOxhgLJBKteAA"
+  "signature": "0elETVng1gkKkMgQF_eTf5kBc-R--GcRFitnxUh65o16douTBodbhG56V1Cdudbcik3E_zkXaqvinpf6oOyADw"
 }
 ```
 ```json
@@ -647,10 +646,10 @@ content-type: application/jose+json
   "payload": {},
   "protected": {
     "alg": "EdDSA",
-    "kid": "https://stepca:33067/acme/wire/account/3f8P2A33xAMTUVnNLJTZeHTCjw08Wxu6",
-    "nonce": "ZEo4S1h6UmVVYVZMSUlNcEN0MERyaTdObmZUQ1dwWUE",
+    "kid": "https://stepca:32787/acme/wire/account/IYFNc4A0aeSpHOVaqOL366OoVNBPUs1f",
+    "nonce": "bUxONUhqOHhFVERFam1YYTVQSm1YYXpNVVRyb3N1dlY",
     "typ": "JWT",
-    "url": "https://stepca:33067/acme/wire/order/D71zUASw1bMHdxcv5z7ZEZPpiImVQo8I"
+    "url": "https://stepca:32787/acme/wire/order/NyuMpBEdChjI5wo4EJEFQOjvb63X68NZ"
   }
 }
 ```
@@ -659,52 +658,52 @@ content-type: application/jose+json
 200
 cache-control: no-store
 content-type: application/json
-link: <https://stepca:33067/acme/wire/directory>;rel="index"
-location: https://stepca:33067/acme/wire/order/D71zUASw1bMHdxcv5z7ZEZPpiImVQo8I
-replay-nonce: RENucXZtUFVUeGNsTmc3enR1WThjdDFEbUxnTHF2WXA
+link: <https://stepca:32787/acme/wire/directory>;rel="index"
+location: https://stepca:32787/acme/wire/order/NyuMpBEdChjI5wo4EJEFQOjvb63X68NZ
+replay-nonce: UFdkTzBJT0VuMVVMTFlZdmhmSzBuaU45MjdsV2JRMEQ
 ```
 ```json
 {
   "status": "ready",
-  "finalize": "https://stepca:33067/acme/wire/order/D71zUASw1bMHdxcv5z7ZEZPpiImVQo8I/finalize",
+  "finalize": "https://stepca:32787/acme/wire/order/NyuMpBEdChjI5wo4EJEFQOjvb63X68NZ/finalize",
   "identifiers": [
     {
       "type": "wireapp-id",
-      "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"im:wireapp=MGExNTA2MDNiMmQ5NDdhNmJmNGFjNGJlNTA2MDYxNmM/a661e79735dc890f@wire.com\",\"handle\":\"im:wireapp=alice_wire\"}"
+      "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"im:wireapp=NjY3NTVhNGYzMzE4NGFjMDgyOGQ5ZTZhOGM3NzYxNTI/ef6a91a91d3337a@wire.com\",\"handle\":\"im:wireapp=alice_wire\"}"
     }
   ],
   "authorizations": [
-    "https://stepca:33067/acme/wire/authz/VZ9OvDd8uCSXMXjXVMfQg63TLUnxGZKk"
+    "https://stepca:32787/acme/wire/authz/VRaT4cBr1eYvRHzU2nXAyT2pUgzUc9ES"
   ],
-  "expires": "2023-06-07T12:08:18Z",
-  "notBefore": "2023-06-06T12:08:18.362732Z",
-  "notAfter": "2033-06-03T12:08:18.362732Z"
+  "expires": "2023-08-01T09:27:52Z",
+  "notBefore": "2023-07-31T09:27:52.754636Z",
+  "notAfter": "2033-07-28T09:27:52.754636Z"
 }
 ```
 #### 28. create a CSR and call finalize url
 ```http request
-POST https://stepca:33067/acme/wire/order/D71zUASw1bMHdxcv5z7ZEZPpiImVQo8I/finalize
+POST https://stepca:32787/acme/wire/order/NyuMpBEdChjI5wo4EJEFQOjvb63X68NZ/finalize
                          /acme/{acme-provisioner}/order/{order-id}/finalize
 content-type: application/jose+json
 ```
 ```json
 {
-  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMzMDY3L2FjbWUvd2lyZS9hY2NvdW50LzNmOFAyQTMzeEFNVFVWbk5MSlRaZUhUQ2p3MDhXeHU2IiwidHlwIjoiSldUIiwibm9uY2UiOiJSRU51Y1hadFVGVlVlR05zVG1jM2VuUjFXVGhqZERGRWJVeG5USEYyV1hBIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzMwNjcvYWNtZS93aXJlL29yZGVyL0Q3MXpVQVN3MWJNSGR4Y3Y1ejdaRVpQcGlJbVZRbzhJL2ZpbmFsaXplIn0",
-  "payload": "eyJjc3IiOiJNSUlCT0RDQjZ3SUJBREF4TVJFd0R3WURWUVFLREFoM2FYSmxMbU52YlRFY01Cb0dDMkNHU0FHRy1FSURBWUZ4REF0QmJHbGpaU0JUYldsMGFEQXFNQVVHQXl0bGNBTWhBRVpNTGR1ckc4LU9FeGNCTkMyWVowNUZQSElQeW5JbEtRX1Yxc3RCS3FOT29JR0dNSUdEQmdrcWhraUc5dzBCQ1E0eGRqQjBNSElHQTFVZEVRUnJNR21HVUdsdE9uZHBjbVZoY0hBOVRVZEZlRTVVUVRKTlJFNXBUVzFSTlU1RVpHaE9iVXB0VGtkR2FrNUhTbXhPVkVFeVRVUlplRTV0VFM5aE5qWXhaVGM1TnpNMVpHTTRPVEJtUUhkcGNtVXVZMjl0aGhWcGJUcDNhWEpsWVhCd1BXRnNhV05sWDNkcGNtVXdCUVlESzJWd0EwRUFBbFRtT3NNQ3RHWWh1SXJXSUJQM1hnMEpaa1FlV05QWXZhT1JTdVk5Q0RocklOZDVsT3dHX01NTmZSQ0tZeDN5U2xGNTZ2eGs4Q2RiQTVncnZfdjdBQSJ9",
-  "signature": "VfUsAIrUndXLa6Iwmlj3LfHeUaS9V0czAo1NhSTy-7iOQNmH9gcRQ85oowZn4o9an3M8HzOwgNuMfFvN8IcNAg"
+  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMyNzg3L2FjbWUvd2lyZS9hY2NvdW50L0lZRk5jNEEwYWVTcEhPVmFxT0wzNjZPb1ZOQlBVczFmIiwidHlwIjoiSldUIiwibm9uY2UiOiJVRmRrVHpCSlQwVnVNVlZNVEZsWmRtaG1TekJ1YVU0NU1qZHNWMkpSTUVRIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI3ODcvYWNtZS93aXJlL29yZGVyL055dU1wQkVkQ2hqSTV3bzRFSkVGUU9qdmI2M1g2OE5aL2ZpbmFsaXplIn0",
+  "payload": "eyJjc3IiOiJNSUlCTnpDQjZnSUJBREF4TVJFd0R3WURWUVFLREFoM2FYSmxMbU52YlRFY01Cb0dDMkNHU0FHRy1FSURBWUZ4REF0QmJHbGpaU0JUYldsMGFEQXFNQVVHQXl0bGNBTWhBSzFpRDAySldTdzlEWTZ5QkE4SmV1TmswUi0wY1YyX1lBSjJvNXp0R200YW9JR0ZNSUdDQmdrcWhraUc5dzBCQ1E0eGRUQnpNSEVHQTFVZEVRUnFNR2lHVDJsdE9uZHBjbVZoY0hBOVRtcFpNMDVVVm1oT1IxbDZUWHBGTkU1SFJtcE5SR2Q1VDBkUk5WcFVXbWhQUjAwelRucFplRTVVU1M5bFpqWmhPVEZoT1RGa016TXpOMkZBZDJseVpTNWpiMjJHRldsdE9uZHBjbVZoY0hBOVlXeHBZMlZmZDJseVpUQUZCZ01yWlhBRFFRQUZiMXhKcEEzLXZkS3U3MWM5cEktM2otN0tYVVpURHhYTTdhMUFmcmRJTl81OVdGWlZrOHpIZWZqdjBLYi1YLXRmektVM05WYmFGLXFMSjRSdWlIY0oifQ",
+  "signature": "5XYPjUdteFrGtUnlINgVacNZpmtDvXqavafhVEJT-ZYSDQq-l9dc_NoHVDIS6zLzFcmDt5e68vr_g0GiktnWCA"
 }
 ```
 ```json
 {
   "payload": {
-    "csr": "MIIBODCB6wIBADAxMREwDwYDVQQKDAh3aXJlLmNvbTEcMBoGC2CGSAGG-EIDAYFxDAtBbGljZSBTbWl0aDAqMAUGAytlcAMhAEZMLdurG8-OExcBNC2YZ05FPHIPynIlKQ_V1stBKqNOoIGGMIGDBgkqhkiG9w0BCQ4xdjB0MHIGA1UdEQRrMGmGUGltOndpcmVhcHA9TUdFeE5UQTJNRE5pTW1RNU5EZGhObUptTkdGak5HSmxOVEEyTURZeE5tTS9hNjYxZTc5NzM1ZGM4OTBmQHdpcmUuY29thhVpbTp3aXJlYXBwPWFsaWNlX3dpcmUwBQYDK2VwA0EAAlTmOsMCtGYhuIrWIBP3Xg0JZkQeWNPYvaORSuY9CDhrINd5lOwG_MMNfRCKYx3ySlF56vxk8CdbA5grv_v7AA"
+    "csr": "MIIBNzCB6gIBADAxMREwDwYDVQQKDAh3aXJlLmNvbTEcMBoGC2CGSAGG-EIDAYFxDAtBbGljZSBTbWl0aDAqMAUGAytlcAMhAK1iD02JWSw9DY6yBA8JeuNk0R-0cV2_YAJ2o5ztGm4aoIGFMIGCBgkqhkiG9w0BCQ4xdTBzMHEGA1UdEQRqMGiGT2ltOndpcmVhcHA9TmpZM05UVmhOR1l6TXpFNE5HRmpNRGd5T0dRNVpUWmhPR00zTnpZeE5USS9lZjZhOTFhOTFkMzMzN2FAd2lyZS5jb22GFWltOndpcmVhcHA9YWxpY2Vfd2lyZTAFBgMrZXADQQAFb1xJpA3-vdKu71c9pI-3j-7KXUZTDxXM7a1AfrdIN_59WFZVk8zHefjv0Kb-X-tfzKU3NVbaF-qLJ4RuiHcJ"
   },
   "protected": {
     "alg": "EdDSA",
-    "kid": "https://stepca:33067/acme/wire/account/3f8P2A33xAMTUVnNLJTZeHTCjw08Wxu6",
-    "nonce": "RENucXZtUFVUeGNsTmc3enR1WThjdDFEbUxnTHF2WXA",
+    "kid": "https://stepca:32787/acme/wire/account/IYFNc4A0aeSpHOVaqOL366OoVNBPUs1f",
+    "nonce": "UFdkTzBJT0VuMVVMTFlZdmhmSzBuaU45MjdsV2JRMEQ",
     "typ": "JWT",
-    "url": "https://stepca:33067/acme/wire/order/D71zUASw1bMHdxcv5z7ZEZPpiImVQo8I/finalize"
+    "url": "https://stepca:32787/acme/wire/order/NyuMpBEdChjI5wo4EJEFQOjvb63X68NZ/finalize"
   }
 }
 ```
@@ -712,13 +711,13 @@ content-type: application/jose+json
 openssl -verify ✅
 ```
 -----BEGIN CERTIFICATE REQUEST-----
-MIIBODCB6wIBADAxMREwDwYDVQQKDAh3aXJlLmNvbTEcMBoGC2CGSAGG+EIDAYFx
-DAtBbGljZSBTbWl0aDAqMAUGAytlcAMhAEZMLdurG8+OExcBNC2YZ05FPHIPynIl
-KQ/V1stBKqNOoIGGMIGDBgkqhkiG9w0BCQ4xdjB0MHIGA1UdEQRrMGmGUGltOndp
-cmVhcHA9TUdFeE5UQTJNRE5pTW1RNU5EZGhObUptTkdGak5HSmxOVEEyTURZeE5t
-TS9hNjYxZTc5NzM1ZGM4OTBmQHdpcmUuY29thhVpbTp3aXJlYXBwPWFsaWNlX3dp
-cmUwBQYDK2VwA0EAAlTmOsMCtGYhuIrWIBP3Xg0JZkQeWNPYvaORSuY9CDhrINd5
-lOwG/MMNfRCKYx3ySlF56vxk8CdbA5grv/v7AA==
+MIIBNzCB6gIBADAxMREwDwYDVQQKDAh3aXJlLmNvbTEcMBoGC2CGSAGG+EIDAYFx
+DAtBbGljZSBTbWl0aDAqMAUGAytlcAMhAK1iD02JWSw9DY6yBA8JeuNk0R+0cV2/
+YAJ2o5ztGm4aoIGFMIGCBgkqhkiG9w0BCQ4xdTBzMHEGA1UdEQRqMGiGT2ltOndp
+cmVhcHA9TmpZM05UVmhOR1l6TXpFNE5HRmpNRGd5T0dRNVpUWmhPR00zTnpZeE5U
+SS9lZjZhOTFhOTFkMzMzN2FAd2lyZS5jb22GFWltOndpcmVhcHA9YWxpY2Vfd2ly
+ZTAFBgMrZXADQQAFb1xJpA3+vdKu71c9pI+3j+7KXUZTDxXM7a1AfrdIN/59WFZV
+k8zHefjv0Kb+X+tfzKU3NVbaF+qLJ4RuiHcJ
 -----END CERTIFICATE REQUEST-----
 
 ```
@@ -731,19 +730,19 @@ Certificate Request:
             Public Key Algorithm: ED25519
                 ED25519 Public-Key:
                 pub:
-                    46:4c:2d:db:ab:1b:cf:8e:13:17:01:34:2d:98:67:
-                    4e:45:3c:72:0f:ca:72:25:29:0f:d5:d6:cb:41:2a:
-                    a3:4e
+                    ad:62:0f:4d:89:59:2c:3d:0d:8e:b2:04:0f:09:7a:
+                    e3:64:d1:1f:b4:71:5d:bf:60:02:76:a3:9c:ed:1a:
+                    6e:1a
         Attributes:
             Requested Extensions:
                 X509v3 Subject Alternative Name: 
-                    URI:im:wireapp=MGExNTA2MDNiMmQ5NDdhNmJmNGFjNGJlNTA2MDYxNmM/a661e79735dc890f@wire.com, URI:im:wireapp=alice_wire
+                    URI:im:wireapp=NjY3NTVhNGYzMzE4NGFjMDgyOGQ5ZTZhOGM3NzYxNTI/ef6a91a91d3337a@wire.com, URI:im:wireapp=alice_wire
     Signature Algorithm: ED25519
     Signature Value:
-        02:54:e6:3a:c3:02:b4:66:21:b8:8a:d6:20:13:f7:5e:0d:09:
-        66:44:1e:58:d3:d8:bd:a3:91:4a:e6:3d:08:38:6b:20:d7:79:
-        94:ec:06:fc:c3:0d:7d:10:8a:63:1d:f2:4a:51:79:ea:fc:64:
-        f0:27:5b:03:98:2b:bf:fb:fb:00
+        05:6f:5c:49:a4:0d:fe:bd:d2:ae:ef:57:3d:a4:8f:b7:8f:ee:
+        ca:5d:46:53:0f:15:cc:ed:ad:40:7e:b7:48:37:fe:7d:58:56:
+        55:93:cc:c7:79:f8:ef:d0:a6:fe:5f:eb:5f:cc:a5:37:35:56:
+        da:17:ea:8b:27:84:6e:88:77:09
 
 ```
 
@@ -752,40 +751,40 @@ Certificate Request:
 200
 cache-control: no-store
 content-type: application/json
-link: <https://stepca:33067/acme/wire/directory>;rel="index"
-location: https://stepca:33067/acme/wire/order/D71zUASw1bMHdxcv5z7ZEZPpiImVQo8I
-replay-nonce: SWlEUmRQVHoyUG5KejhQTWt3UXJjTXZSRjlvUWNKTHA
+link: <https://stepca:32787/acme/wire/directory>;rel="index"
+location: https://stepca:32787/acme/wire/order/NyuMpBEdChjI5wo4EJEFQOjvb63X68NZ
+replay-nonce: dVZEY3EzMENsOVB5TTdqQ0xLUGNMa3FyT2MwNHV0cUI
 ```
 ```json
 {
-  "certificate": "https://stepca:33067/acme/wire/certificate/MPd3TpyTezfB7zED0ZBo2HPwCrCDDhHT",
+  "certificate": "https://stepca:32787/acme/wire/certificate/DHrQ0c6czMSXpJlF36wt0PptFHMLvmQW",
   "status": "valid",
-  "finalize": "https://stepca:33067/acme/wire/order/D71zUASw1bMHdxcv5z7ZEZPpiImVQo8I/finalize",
+  "finalize": "https://stepca:32787/acme/wire/order/NyuMpBEdChjI5wo4EJEFQOjvb63X68NZ/finalize",
   "identifiers": [
     {
       "type": "wireapp-id",
-      "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"im:wireapp=MGExNTA2MDNiMmQ5NDdhNmJmNGFjNGJlNTA2MDYxNmM/a661e79735dc890f@wire.com\",\"handle\":\"im:wireapp=alice_wire\"}"
+      "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"im:wireapp=NjY3NTVhNGYzMzE4NGFjMDgyOGQ5ZTZhOGM3NzYxNTI/ef6a91a91d3337a@wire.com\",\"handle\":\"im:wireapp=alice_wire\"}"
     }
   ],
   "authorizations": [
-    "https://stepca:33067/acme/wire/authz/VZ9OvDd8uCSXMXjXVMfQg63TLUnxGZKk"
+    "https://stepca:32787/acme/wire/authz/VRaT4cBr1eYvRHzU2nXAyT2pUgzUc9ES"
   ],
-  "expires": "2023-06-07T12:08:18Z",
-  "notBefore": "2023-06-06T12:08:18.362732Z",
-  "notAfter": "2033-06-03T12:08:18.362732Z"
+  "expires": "2023-08-01T09:27:52Z",
+  "notBefore": "2023-07-31T09:27:52.754636Z",
+  "notAfter": "2033-07-28T09:27:52.754636Z"
 }
 ```
 #### 30. fetch the certificate
 ```http request
-POST https://stepca:33067/acme/wire/certificate/MPd3TpyTezfB7zED0ZBo2HPwCrCDDhHT
+POST https://stepca:32787/acme/wire/certificate/DHrQ0c6czMSXpJlF36wt0PptFHMLvmQW
                          /acme/{acme-provisioner}/certificate/{certificate-id}
 content-type: application/jose+json
 ```
 ```json
 {
-  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMzMDY3L2FjbWUvd2lyZS9hY2NvdW50LzNmOFAyQTMzeEFNVFVWbk5MSlRaZUhUQ2p3MDhXeHU2IiwidHlwIjoiSldUIiwibm9uY2UiOiJTV2xFVW1SUVZIb3lVRzVLZWpoUVRXdDNVWEpqVFhaU1JqbHZVV05LVEhBIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzMwNjcvYWNtZS93aXJlL2NlcnRpZmljYXRlL01QZDNUcHlUZXpmQjd6RUQwWkJvMkhQd0NyQ0REaEhUIn0",
+  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMyNzg3L2FjbWUvd2lyZS9hY2NvdW50L0lZRk5jNEEwYWVTcEhPVmFxT0wzNjZPb1ZOQlBVczFmIiwidHlwIjoiSldUIiwibm9uY2UiOiJkVlpFWTNFek1FTnNPVkI1VFRkcVEweExVR05NYTNGeVQyTXdOSFYwY1VJIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI3ODcvYWNtZS93aXJlL2NlcnRpZmljYXRlL0RIclEwYzZjek1TWHBKbEYzNnd0MFBwdEZITUx2bVFXIn0",
   "payload": "",
-  "signature": "0SsKraW0kTsCLA6oL0iMifa2Wgo_HMFg6prH5rT-hH42hjQJgoaqtTju-HjIQBKP6o4SaDHLCBGlswHdDPTRBg"
+  "signature": "mzZC9WlQbqH-bO5sudSf7EyJg5785mHeB5tgkJWmaXtGv3K23mEU-P1nvhdPQM2pAK1Y6OBiUrjPBqb0w8cECQ"
 }
 ```
 ```json
@@ -793,10 +792,10 @@ content-type: application/jose+json
   "payload": {},
   "protected": {
     "alg": "EdDSA",
-    "kid": "https://stepca:33067/acme/wire/account/3f8P2A33xAMTUVnNLJTZeHTCjw08Wxu6",
-    "nonce": "SWlEUmRQVHoyUG5KejhQTWt3UXJjTXZSRjlvUWNKTHA",
+    "kid": "https://stepca:32787/acme/wire/account/IYFNc4A0aeSpHOVaqOL366OoVNBPUs1f",
+    "nonce": "dVZEY3EzMENsOVB5TTdqQ0xLUGNMa3FyT2MwNHV0cUI",
     "typ": "JWT",
-    "url": "https://stepca:33067/acme/wire/certificate/MPd3TpyTezfB7zED0ZBo2HPwCrCDDhHT"
+    "url": "https://stepca:32787/acme/wire/certificate/DHrQ0c6czMSXpJlF36wt0PptFHMLvmQW"
   }
 }
 ```
@@ -805,28 +804,28 @@ content-type: application/jose+json
 200
 cache-control: no-store
 content-type: application/pem-certificate-chain
-link: <https://stepca:33067/acme/wire/directory>;rel="index"
-replay-nonce: UWNVaE1SODE5TzF0ckloSEZrRTc4RDU0a1RPQ2FnbTI
+link: <https://stepca:32787/acme/wire/directory>;rel="index"
+replay-nonce: UE0xWkY2UWp0ald5M1BNZzdpc3R5QTBkdzBIOGNJNGg
 ```
 ```json
-"-----BEGIN CERTIFICATE-----\nMIICIzCCAcmgAwIBAgIRAMenThsAtlCIhqyCAVH0GEEwCgYIKoZIzj0EAwIwLjEN\nMAsGA1UEChMEd2lyZTEdMBsGA1UEAxMUd2lyZSBJbnRlcm1lZGlhdGUgQ0EwHhcN\nMjMwNjA2MTIwODE4WhcNMzMwNjAzMTIwODE4WjApMREwDwYDVQQKEwh3aXJlLmNv\nbTEUMBIGA1UEAxMLQWxpY2UgU21pdGgwKjAFBgMrZXADIQBGTC3bqxvPjhMXATQt\nmGdORTxyD8pyJSkP1dbLQSqjTqOB+zCB+DAOBgNVHQ8BAf8EBAMCB4AwEwYDVR0l\nBAwwCgYIKwYBBQUHAwIwHQYDVR0OBBYEFNKA345X524Q+SHCLQ00zZ0cdBNoMB8G\nA1UdIwQYMBaAFME5AwrCFGOqvFlmddEH2+uh+tiRMHIGA1UdEQRrMGmGFWltOndp\ncmVhcHA9YWxpY2Vfd2lyZYZQaW06d2lyZWFwcD1NR0V4TlRBMk1ETmlNbVE1TkRk\naE5tSm1OR0ZqTkdKbE5UQTJNRFl4Tm1NL2E2NjFlNzk3MzVkYzg5MGZAd2lyZS5j\nb20wHQYMKwYBBAGCpGTGKEABBA0wCwIBBgQEd2lyZQQAMAoGCCqGSM49BAMCA0gA\nMEUCIQDZtqoDW2/voz+Bxv+arvKs4D9LrYcLrxZggqoyfDlXtwIgWQydK7muAf4A\npK3eVnJT+lAkA0ez9GGQhsceZNe80SE=\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIBuTCCAV+gAwIBAgIRAP/U+N1JHsvQGzup+9TuHtYwCgYIKoZIzj0EAwIwJjEN\nMAsGA1UEChMEd2lyZTEVMBMGA1UEAxMMd2lyZSBSb290IENBMB4XDTIzMDYwNjEy\nMDgxNVoXDTMzMDYwMzEyMDgxNVowLjENMAsGA1UEChMEd2lyZTEdMBsGA1UEAxMU\nd2lyZSBJbnRlcm1lZGlhdGUgQ0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASb\nU608O/JI9Zuludc4npVxoIxiqmVF6fW0HVcPh0qJVIbOi31PHNP3j2+MHG0aMCaS\n7OxDLufmg5YdnDN3JCaxo2YwZDAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgw\nBgEB/wIBADAdBgNVHQ4EFgQUwTkDCsIUY6q8WWZ10Qfb66H62JEwHwYDVR0jBBgw\nFoAUbP1RpVa66tSHaLyK7VmFyP0n9WQwCgYIKoZIzj0EAwIDSAAwRQIhAPKAMr9+\ncTWiPuFpdomnTBZRB7wwAk9dKR5a/l02Jx6OAiBebfLGFRQ1psRWsomqt8LGjjZ7\n5TVDcCtvnOTq+MSIJw==\n-----END CERTIFICATE-----\n"
+"-----BEGIN CERTIFICATE-----\nMIICITCCAcegAwIBAgIQR1p0BYNat2/TaZ6fQ0VMEzAKBggqhkjOPQQDAjAuMQ0w\nCwYDVQQKEwR3aXJlMR0wGwYDVQQDExR3aXJlIEludGVybWVkaWF0ZSBDQTAeFw0y\nMzA3MzEwOTI3NTJaFw0zMzA3MjgwOTI3NTJaMCkxETAPBgNVBAoTCHdpcmUuY29t\nMRQwEgYDVQQDEwtBbGljZSBTbWl0aDAqMAUGAytlcAMhAK1iD02JWSw9DY6yBA8J\neuNk0R+0cV2/YAJ2o5ztGm4ao4H6MIH3MA4GA1UdDwEB/wQEAwIHgDATBgNVHSUE\nDDAKBggrBgEFBQcDAjAdBgNVHQ4EFgQU9r3Fgf8j7EW1YqMX5PJRTnzP2JowHwYD\nVR0jBBgwFoAUKrfsq6lXfJxv+1K6ZqL+nQF7JM8wcQYDVR0RBGowaIYVaW06d2ly\nZWFwcD1hbGljZV93aXJlhk9pbTp3aXJlYXBwPU5qWTNOVFZoTkdZek16RTROR0Zq\nTURneU9HUTVaVFpoT0dNM056WXhOVEkvZWY2YTkxYTkxZDMzMzdhQHdpcmUuY29t\nMB0GDCsGAQQBgqRkxihAAQQNMAsCAQYEBHdpcmUEADAKBggqhkjOPQQDAgNIADBF\nAiEAnF9mIGN0oYJoK9wdCKFKa7nMrdmQFn/jpPW6c8XaaegCIA44rKycEh1zHB/W\n0lQDi9BobI4bjNc3KI3xDXTBQ8zD\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIBuDCCAV+gAwIBAgIRANQWShCNltymDyF5wZjoItswCgYIKoZIzj0EAwIwJjEN\nMAsGA1UEChMEd2lyZTEVMBMGA1UEAxMMd2lyZSBSb290IENBMB4XDTIzMDczMTA5\nMjc1MVoXDTMzMDcyODA5Mjc1MVowLjENMAsGA1UEChMEd2lyZTEdMBsGA1UEAxMU\nd2lyZSBJbnRlcm1lZGlhdGUgQ0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASx\nZNVsvP/BinJ2Vr7b2cC5jIHATJRsR9d3JdIdh7GArgsE4dHns1U3N6cbR5UYI1UA\n3L07+DFTYTw/SnC78mdko2YwZDAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgw\nBgEB/wIBADAdBgNVHQ4EFgQUKrfsq6lXfJxv+1K6ZqL+nQF7JM8wHwYDVR0jBBgw\nFoAUHk5gRHkSTo8fs6gmiZKhCaDi3ggwCgYIKoZIzj0EAwIDRwAwRAIgS7eV9Ev8\naOI/WLLaRhqzwgJML557AUybtMmpygAbRCQCIGnlpyv2NvRTaRahYV1ZlB5VXMxQ\nsjraUYrz4GWJu9Kg\n-----END CERTIFICATE-----\n"
 ```
 ###### Certificate #1
 openssl -verify ✅
 ```
 -----BEGIN CERTIFICATE-----
-MIICIzCCAcmgAwIBAgIRAMenThsAtlCIhqyCAVH0GEEwCgYIKoZIzj0EAwIwLjEN
-MAsGA1UEChMEd2lyZTEdMBsGA1UEAxMUd2lyZSBJbnRlcm1lZGlhdGUgQ0EwHhcN
-MjMwNjA2MTIwODE4WhcNMzMwNjAzMTIwODE4WjApMREwDwYDVQQKEwh3aXJlLmNv
-bTEUMBIGA1UEAxMLQWxpY2UgU21pdGgwKjAFBgMrZXADIQBGTC3bqxvPjhMXATQt
-mGdORTxyD8pyJSkP1dbLQSqjTqOB+zCB+DAOBgNVHQ8BAf8EBAMCB4AwEwYDVR0l
-BAwwCgYIKwYBBQUHAwIwHQYDVR0OBBYEFNKA345X524Q+SHCLQ00zZ0cdBNoMB8G
-A1UdIwQYMBaAFME5AwrCFGOqvFlmddEH2+uh+tiRMHIGA1UdEQRrMGmGFWltOndp
-cmVhcHA9YWxpY2Vfd2lyZYZQaW06d2lyZWFwcD1NR0V4TlRBMk1ETmlNbVE1TkRk
-aE5tSm1OR0ZqTkdKbE5UQTJNRFl4Tm1NL2E2NjFlNzk3MzVkYzg5MGZAd2lyZS5j
-b20wHQYMKwYBBAGCpGTGKEABBA0wCwIBBgQEd2lyZQQAMAoGCCqGSM49BAMCA0gA
-MEUCIQDZtqoDW2/voz+Bxv+arvKs4D9LrYcLrxZggqoyfDlXtwIgWQydK7muAf4A
-pK3eVnJT+lAkA0ez9GGQhsceZNe80SE=
+MIICITCCAcegAwIBAgIQR1p0BYNat2/TaZ6fQ0VMEzAKBggqhkjOPQQDAjAuMQ0w
+CwYDVQQKEwR3aXJlMR0wGwYDVQQDExR3aXJlIEludGVybWVkaWF0ZSBDQTAeFw0y
+MzA3MzEwOTI3NTJaFw0zMzA3MjgwOTI3NTJaMCkxETAPBgNVBAoTCHdpcmUuY29t
+MRQwEgYDVQQDEwtBbGljZSBTbWl0aDAqMAUGAytlcAMhAK1iD02JWSw9DY6yBA8J
+euNk0R+0cV2/YAJ2o5ztGm4ao4H6MIH3MA4GA1UdDwEB/wQEAwIHgDATBgNVHSUE
+DDAKBggrBgEFBQcDAjAdBgNVHQ4EFgQU9r3Fgf8j7EW1YqMX5PJRTnzP2JowHwYD
+VR0jBBgwFoAUKrfsq6lXfJxv+1K6ZqL+nQF7JM8wcQYDVR0RBGowaIYVaW06d2ly
+ZWFwcD1hbGljZV93aXJlhk9pbTp3aXJlYXBwPU5qWTNOVFZoTkdZek16RTROR0Zq
+TURneU9HUTVaVFpoT0dNM056WXhOVEkvZWY2YTkxYTkxZDMzMzdhQHdpcmUuY29t
+MB0GDCsGAQQBgqRkxihAAQQNMAsCAQYEBHdpcmUEADAKBggqhkjOPQQDAgNIADBF
+AiEAnF9mIGN0oYJoK9wdCKFKa7nMrdmQFn/jpPW6c8XaaegCIA44rKycEh1zHB/W
+0lQDi9BobI4bjNc3KI3xDXTBQ8zD
 -----END CERTIFICATE-----
 
 ```
@@ -835,39 +834,39 @@ Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number:
-            c7:a7:4e:1b:00:b6:50:88:86:ac:82:01:51:f4:18:41
+            47:5a:74:05:83:5a:b7:6f:d3:69:9e:9f:43:45:4c:13
         Signature Algorithm: ecdsa-with-SHA256
         Issuer: O = wire, CN = wire Intermediate CA
         Validity
-            Not Before: Jun  6 12:08:18 2023 GMT
-            Not After : Jun  3 12:08:18 2033 GMT
+            Not Before: Jul 31 09:27:52 2023 GMT
+            Not After : Jul 28 09:27:52 2033 GMT
         Subject: O = wire.com, CN = Alice Smith
         Subject Public Key Info:
             Public Key Algorithm: ED25519
                 ED25519 Public-Key:
                 pub:
-                    46:4c:2d:db:ab:1b:cf:8e:13:17:01:34:2d:98:67:
-                    4e:45:3c:72:0f:ca:72:25:29:0f:d5:d6:cb:41:2a:
-                    a3:4e
+                    ad:62:0f:4d:89:59:2c:3d:0d:8e:b2:04:0f:09:7a:
+                    e3:64:d1:1f:b4:71:5d:bf:60:02:76:a3:9c:ed:1a:
+                    6e:1a
         X509v3 extensions:
             X509v3 Key Usage: critical
                 Digital Signature
             X509v3 Extended Key Usage: 
                 TLS Web Client Authentication
             X509v3 Subject Key Identifier: 
-                D2:80:DF:8E:57:E7:6E:10:F9:21:C2:2D:0D:34:CD:9D:1C:74:13:68
+                F6:BD:C5:81:FF:23:EC:45:B5:62:A3:17:E4:F2:51:4E:7C:CF:D8:9A
             X509v3 Authority Key Identifier: 
-                C1:39:03:0A:C2:14:63:AA:BC:59:66:75:D1:07:DB:EB:A1:FA:D8:91
+                2A:B7:EC:AB:A9:57:7C:9C:6F:FB:52:BA:66:A2:FE:9D:01:7B:24:CF
             X509v3 Subject Alternative Name: 
-                URI:im:wireapp=alice_wire, URI:im:wireapp=MGExNTA2MDNiMmQ5NDdhNmJmNGFjNGJlNTA2MDYxNmM/a661e79735dc890f@wire.com
+                URI:im:wireapp=alice_wire, URI:im:wireapp=NjY3NTVhNGYzMzE4NGFjMDgyOGQ5ZTZhOGM3NzYxNTI/ef6a91a91d3337a@wire.com
             1.3.6.1.4.1.37476.9000.64.1: 
                 0......wire..
     Signature Algorithm: ecdsa-with-SHA256
     Signature Value:
-        30:45:02:21:00:d9:b6:aa:03:5b:6f:ef:a3:3f:81:c6:ff:9a:
-        ae:f2:ac:e0:3f:4b:ad:87:0b:af:16:60:82:aa:32:7c:39:57:
-        b7:02:20:59:0c:9d:2b:b9:ae:01:fe:00:a4:ad:de:56:72:53:
-        fa:50:24:03:47:b3:f4:61:90:86:c7:1e:64:d7:bc:d1:21
+        30:45:02:21:00:9c:5f:66:20:63:74:a1:82:68:2b:dc:1d:08:
+        a1:4a:6b:b9:cc:ad:d9:90:16:7f:e3:a4:f5:ba:73:c5:da:69:
+        e8:02:20:0e:38:ac:ac:9c:12:1d:73:1c:1f:d6:d2:54:03:8b:
+        d0:68:6c:8e:1b:8c:d7:37:28:8d:f1:0d:74:c1:43:cc:c3
 
 ```
 
@@ -875,16 +874,16 @@ Certificate:
 openssl -verify ✅
 ```
 -----BEGIN CERTIFICATE-----
-MIIBuTCCAV+gAwIBAgIRAP/U+N1JHsvQGzup+9TuHtYwCgYIKoZIzj0EAwIwJjEN
-MAsGA1UEChMEd2lyZTEVMBMGA1UEAxMMd2lyZSBSb290IENBMB4XDTIzMDYwNjEy
-MDgxNVoXDTMzMDYwMzEyMDgxNVowLjENMAsGA1UEChMEd2lyZTEdMBsGA1UEAxMU
-d2lyZSBJbnRlcm1lZGlhdGUgQ0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASb
-U608O/JI9Zuludc4npVxoIxiqmVF6fW0HVcPh0qJVIbOi31PHNP3j2+MHG0aMCaS
-7OxDLufmg5YdnDN3JCaxo2YwZDAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgw
-BgEB/wIBADAdBgNVHQ4EFgQUwTkDCsIUY6q8WWZ10Qfb66H62JEwHwYDVR0jBBgw
-FoAUbP1RpVa66tSHaLyK7VmFyP0n9WQwCgYIKoZIzj0EAwIDSAAwRQIhAPKAMr9+
-cTWiPuFpdomnTBZRB7wwAk9dKR5a/l02Jx6OAiBebfLGFRQ1psRWsomqt8LGjjZ7
-5TVDcCtvnOTq+MSIJw==
+MIIBuDCCAV+gAwIBAgIRANQWShCNltymDyF5wZjoItswCgYIKoZIzj0EAwIwJjEN
+MAsGA1UEChMEd2lyZTEVMBMGA1UEAxMMd2lyZSBSb290IENBMB4XDTIzMDczMTA5
+Mjc1MVoXDTMzMDcyODA5Mjc1MVowLjENMAsGA1UEChMEd2lyZTEdMBsGA1UEAxMU
+d2lyZSBJbnRlcm1lZGlhdGUgQ0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASx
+ZNVsvP/BinJ2Vr7b2cC5jIHATJRsR9d3JdIdh7GArgsE4dHns1U3N6cbR5UYI1UA
+3L07+DFTYTw/SnC78mdko2YwZDAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgw
+BgEB/wIBADAdBgNVHQ4EFgQUKrfsq6lXfJxv+1K6ZqL+nQF7JM8wHwYDVR0jBBgw
+FoAUHk5gRHkSTo8fs6gmiZKhCaDi3ggwCgYIKoZIzj0EAwIDRwAwRAIgS7eV9Ev8
+aOI/WLLaRhqzwgJML557AUybtMmpygAbRCQCIGnlpyv2NvRTaRahYV1ZlB5VXMxQ
+sjraUYrz4GWJu9Kg
 -----END CERTIFICATE-----
 
 ```
@@ -893,22 +892,22 @@ Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number:
-            ff:d4:f8:dd:49:1e:cb:d0:1b:3b:a9:fb:d4:ee:1e:d6
+            d4:16:4a:10:8d:96:dc:a6:0f:21:79:c1:98:e8:22:db
         Signature Algorithm: ecdsa-with-SHA256
         Issuer: O = wire, CN = wire Root CA
         Validity
-            Not Before: Jun  6 12:08:15 2023 GMT
-            Not After : Jun  3 12:08:15 2033 GMT
+            Not Before: Jul 31 09:27:51 2023 GMT
+            Not After : Jul 28 09:27:51 2033 GMT
         Subject: O = wire, CN = wire Intermediate CA
         Subject Public Key Info:
             Public Key Algorithm: id-ecPublicKey
                 Public-Key: (256 bit)
                 pub:
-                    04:9b:53:ad:3c:3b:f2:48:f5:9b:a5:b9:d7:38:9e:
-                    95:71:a0:8c:62:aa:65:45:e9:f5:b4:1d:57:0f:87:
-                    4a:89:54:86:ce:8b:7d:4f:1c:d3:f7:8f:6f:8c:1c:
-                    6d:1a:30:26:92:ec:ec:43:2e:e7:e6:83:96:1d:9c:
-                    33:77:24:26:b1
+                    04:b1:64:d5:6c:bc:ff:c1:8a:72:76:56:be:db:d9:
+                    c0:b9:8c:81:c0:4c:94:6c:47:d7:77:25:d2:1d:87:
+                    b1:80:ae:0b:04:e1:d1:e7:b3:55:37:37:a7:1b:47:
+                    95:18:23:55:00:dc:bd:3b:f8:31:53:61:3c:3f:4a:
+                    70:bb:f2:67:64
                 ASN1 OID: prime256v1
                 NIST CURVE: P-256
         X509v3 extensions:
@@ -917,14 +916,14 @@ Certificate:
             X509v3 Basic Constraints: critical
                 CA:TRUE, pathlen:0
             X509v3 Subject Key Identifier: 
-                C1:39:03:0A:C2:14:63:AA:BC:59:66:75:D1:07:DB:EB:A1:FA:D8:91
+                2A:B7:EC:AB:A9:57:7C:9C:6F:FB:52:BA:66:A2:FE:9D:01:7B:24:CF
             X509v3 Authority Key Identifier: 
-                6C:FD:51:A5:56:BA:EA:D4:87:68:BC:8A:ED:59:85:C8:FD:27:F5:64
+                1E:4E:60:44:79:12:4E:8F:1F:B3:A8:26:89:92:A1:09:A0:E2:DE:08
     Signature Algorithm: ecdsa-with-SHA256
     Signature Value:
-        30:45:02:21:00:f2:80:32:bf:7e:71:35:a2:3e:e1:69:76:89:
-        a7:4c:16:51:07:bc:30:02:4f:5d:29:1e:5a:fe:5d:36:27:1e:
-        8e:02:20:5e:6d:f2:c6:15:14:35:a6:c4:56:b2:89:aa:b7:c2:
-        c6:8e:36:7b:e5:35:43:70:2b:6f:9c:e4:ea:f8:c4:88:27
+        30:44:02:20:4b:b7:95:f4:4b:fc:68:e2:3f:58:b2:da:46:1a:
+        b3:c2:02:4c:2f:9e:7b:01:4c:9b:b4:c9:a9:ca:00:1b:44:24:
+        02:20:69:e5:a7:2b:f6:36:f4:53:69:16:a1:61:5d:59:94:1e:
+        55:5c:cc:50:b2:3a:da:51:8a:f3:e0:65:89:bb:d2:a0
 
 ```

--- a/e2e-identity/tests/utils/docker/stepca.rs
+++ b/e2e-identity/tests/utils/docker/stepca.rs
@@ -100,7 +100,7 @@ pub struct StepCaImage {
 
 impl StepCaImage {
     const NAME: &'static str = "quay.io/wire/smallstep-acme";
-    const TAG: &'static str = "0.0.42-test.85";
+    const TAG: &'static str = "0.0.42-test.89";
     const CA_NAME: &'static str = "wire";
     pub const ACME_PROVISIONER: &'static str = "wire";
     pub const PORT: u16 = 9000;

--- a/e2e-identity/tests/utils/fmk.rs
+++ b/e2e-identity/tests/utils/fmk.rs
@@ -358,6 +358,7 @@ impl<'a> E2eTest<'a> {
 
         self.display_step("DPoP challenge is valid");
         let mut resp = self.client.execute(req).await?;
+
         self.display_resp(Actor::AcmeServer, Actor::WireClient, Some(&resp));
         let previous_nonce = resp.replay_nonce();
         resp.expect_status_ok()

--- a/ffi/Cargo.lock
+++ b/ffi/Cargo.lock
@@ -1058,6 +1058,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,6 +1408,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -1792,7 +1807,7 @@ dependencies = [
  "dyn-clone",
  "hmac",
  "http",
- "itertools",
+ "itertools 0.10.5",
  "log",
  "oauth2",
  "p256 0.11.1",
@@ -1970,9 +1985,9 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
+checksum = "64c94164abe2135d777f6d89799f7ceadc9b45390f44bc361e32cd8854f1a125"
 dependencies = [
  "base64 0.21.2",
  "serde",
@@ -2295,7 +2310,7 @@ checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "multimap",
@@ -2316,7 +2331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2474,6 +2489,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
+name = "relative-path"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bf2521270932c3c7bed1a59151222bd7643c79310f2916f01925e1e16255698"
+
+[[package]]
 name = "reqwest"
 version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2584,9 +2605,9 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de1bb486a691878cd320c2f0d319ba91eeaa2e894066d8b5f8f117c000e9d962"
+checksum = "2b96577ca10cb3eade7b337eb46520108a67ca2818a24d0b63f41fd62bc9651c"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2596,28 +2617,31 @@ dependencies = [
 
 [[package]]
 name = "rstest_macros"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8"
+checksum = "225e674cf31712b8bb15fdbca3ec0c1b9d825c5a24407ff2b7e005fb6a29ba03"
 dependencies = [
  "cfg-if",
+ "glob",
  "proc-macro2",
  "quote",
+ "regex",
+ "relative-path",
  "rustc_version",
- "syn 1.0.109",
+ "syn 2.0.18",
  "unicode-ident",
 ]
 
 [[package]]
 name = "rstest_reuse"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45f80dcc84beab3a327bbe161f77db25f336a1452428176787c8c79ac79d7073"
+checksum = "88530b681abe67924d42cca181d070e3ac20e0740569441a9e35a7cedd2b34a4"
 dependencies = [
  "quote",
  "rand 0.8.5",
  "rustc_version",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2685,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "rusty-acme"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "asn1-rs",
  "base64 0.21.2",
@@ -2696,7 +2720,7 @@ dependencies = [
  "oid-registry",
  "p256 0.13.2",
  "p384 0.13.0",
- "pem 2.0.1",
+ "pem 3.0.0",
  "rusty-jwt-tools",
  "serde",
  "serde_json",
@@ -2710,7 +2734,7 @@ dependencies = [
 
 [[package]]
 name = "rusty-jwt-cli"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -2722,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "rusty-jwt-tools"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "base64 0.21.2",
  "biscuit",
@@ -2754,7 +2778,7 @@ dependencies = [
 
 [[package]]
 name = "rusty-jwt-tools-ffi"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "rusty-jwt-tools",
  "uuid",
@@ -3858,7 +3882,7 @@ dependencies = [
 
 [[package]]
 name = "wire-e2e-identity"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "asserhttp",
@@ -3868,13 +3892,13 @@ dependencies = [
  "html_parser",
  "http",
  "hyper",
- "itertools",
+ "itertools 0.11.0",
  "jwt-simple",
  "lazy_static",
  "oauth2",
  "oid-registry",
  "openidconnect",
- "pem 2.0.1",
+ "pem 3.0.0",
  "portpicker",
  "rand 0.8.5",
  "rcgen",

--- a/jwt/src/dpop/verify.rs
+++ b/jwt/src/dpop/verify.rs
@@ -64,7 +64,7 @@ impl VerifyDpop for &str {
             issuer: None,
         };
 
-        let claims = (*self).verify_jwt::<Dpop>(&pk, max_expiration, None, None, verify)?;
+        let claims = (*self).verify_jwt::<Dpop>(&pk, max_expiration, verify)?;
         if let Some(expected_htm) = htm {
             if expected_htm != claims.custom.htm {
                 return Err(RustyJwtError::DpopHtmMismatch);

--- a/jwt/src/jwt/verify.rs
+++ b/jwt/src/jwt/verify.rs
@@ -3,7 +3,6 @@
 use jwt_simple::prelude::*;
 use serde::de::DeserializeOwned;
 
-use crate::jwk_thumbprint::JwkThumbprint;
 use crate::prelude::*;
 
 /// Global trait to verify a Jwt token
@@ -61,8 +60,9 @@ pub trait VerifyJwt {
         &self,
         key: &AnyPublicKey,
         max_expiration: u64,
-        expected_cnf: Option<&JwkThumbprint>,
-        actual_cnf: Option<fn(&JWTClaims<T>) -> &JwkThumbprint>,
+        // expected_cnf: Option<&JwkThumbprint>,
+        // actual_cnf: Option<fn(&JWTClaims<T>) -> &JwkThumbprint>,
+        // custom: Option<fn(&JWTClaims<T>) -> RustyJwtResult<JWTClaims<T>>>,
         verify: Verify,
     ) -> RustyJwtResult<JWTClaims<T>>
     where
@@ -74,8 +74,9 @@ impl VerifyJwt for &str {
         &self,
         key: &AnyPublicKey<'_>,
         max_expiration: u64,
-        expected_cnf: Option<&JwkThumbprint>,
-        actual_cnf: Option<fn(&JWTClaims<T>) -> &JwkThumbprint>,
+        // expected_cnf: Option<&JwkThumbprint>,
+        // actual_cnf: Option<fn(&JWTClaims<T>) -> &JwkThumbprint>,
+        // custom: Option<fn(&JWTClaims<T>) -> RustyJwtResult<JWTClaims<T>>>,
         verify: Verify,
     ) -> RustyJwtResult<JWTClaims<T>>
     where
@@ -92,12 +93,12 @@ impl VerifyJwt for &str {
             return Err(RustyJwtError::TokenLivesTooLong);
         }
 
-        if let Some((expected_cnf, actual_cnf)) = expected_cnf.zip(actual_cnf) {
+        /*if let Some((expected_cnf, actual_cnf)) = expected_cnf.zip(actual_cnf) {
             let actual_cnf = actual_cnf(&claims);
             if expected_cnf != actual_cnf {
                 return Err(RustyJwtError::InvalidJwkThumbprint);
             }
-        }
+        }*/
 
         Ok(claims)
     }

--- a/jwt/src/test_utils/access.rs
+++ b/jwt/src/test_utils/access.rs
@@ -21,9 +21,12 @@ impl From<Ciphersuite> for TestAccess {
     fn from(ciphersuite: Ciphersuite) -> Self {
         let access = Access::default();
         let proof = DpopBuilder::from(ciphersuite.key.clone()).build();
+        let proof_header = Token::decode_metadata(&proof).unwrap();
+        let proof_jwk = proof_header.public_key().unwrap();
+        let cnf = JwkThumbprint::generate(proof_jwk, ciphersuite.hash).unwrap();
         Self {
             challenge: Some(access.challenge),
-            cnf: Some(ciphersuite.to_jwk_thumbprint()),
+            cnf: Some(cnf),
             proof: Some(proof),
             client_id: Some(ClientId::default()),
             api_version: Some(Access::WIRE_SERVER_API_VERSION),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Change dpop access token 'cnf' from self JWK to client dpop token JWK.

Previously, the 'cnf' claim in the dpop access token (generated by wire-server) was the JWK thumbprint of the dpop access token. Now, it is the JWK thumbprint of the client dpop token. That way, ACME server can verify that the access token it validates (as part of the DPOP challenge) is the one issued for the client it has an order for.

TODO: need to release a new version of smallstep with this commit to have e2e tests pass.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
