### PR TITLE
fix: seal keyauth in OIDC id token by using Keycloak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +609,34 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "cookie"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d606d0fba62e13cf04db20536c05cb7f13673c161cb47a47a82b9b9e7d3f1daa"
+dependencies = [
+ "cookie",
+ "idna 0.2.3",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1585,6 +1624,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,6 +1664,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "idna"
@@ -1802,6 +1875,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "keycloak"
+version = "21.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6135dc80c085ab1f8fab0c17a0238df2044660bfbc1665fc3123ef1128cae9"
+dependencies = [
+ "async-trait",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_with 2.3.3",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,6 +2034,24 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "ndarray"
@@ -2178,6 +2282,12 @@ dependencies = [
  "quote",
  "syn 2.0.48",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
@@ -2667,6 +2777,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a8c1bda5ae1af7f99a2962e49df150414a43d62404644d98dd5c3a93d07457"
+dependencies = [
+ "idna 0.3.0",
+ "psl-types",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2851,6 +2977,8 @@ checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
  "base64 0.21.7",
  "bytes",
+ "cookie",
+ "cookie_store",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -2859,10 +2987,12 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -2873,6 +3003,7 @@ dependencies = [
  "serde_urlencoded",
  "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower-service",
  "url",
@@ -3186,6 +3317,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3235,6 +3375,29 @@ dependencies = [
  "pkcs8 0.10.2",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3359,6 +3522,22 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "serde",
+ "serde_json",
+ "serde_with_macros 2.3.3",
+ "time",
+]
+
+[[package]]
+name = "serde_with"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
@@ -3384,6 +3563,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
+dependencies = [
+ "darling 0.20.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3776,6 +3967,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3910,7 +4111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.5.0",
  "percent-encoding",
  "serde",
 ]
@@ -4383,6 +4584,7 @@ dependencies = [
  "hyper",
  "itertools 0.12.0",
  "jwt-simple",
+ "keycloak",
  "lazy_static",
  "oauth2",
  "oid-registry",

--- a/acme/src/chall.rs
+++ b/acme/src/chall.rs
@@ -1,6 +1,6 @@
-use crate::prelude::*;
-use jwt_simple::prelude::*;
 use rusty_jwt_tools::prelude::*;
+
+use crate::prelude::*;
 
 impl RustyAcme {
     /// client id challenge request to `POST /acme/challenge/{token}`
@@ -32,21 +32,13 @@ impl RustyAcme {
         oidc_chall: AcmeChallenge,
         account: &AcmeAccount,
         alg: JwsAlgorithm,
-        hash_alg: HashAlgorithm,
         kp: &Pem,
-        jwk: &Jwk,
         previous_nonce: String,
     ) -> RustyAcmeResult<AcmeJws> {
         // Extract the account URL from previous response which created a new account
         let acct_url = account.acct_url()?;
-
-        let thumbprint = JwkThumbprint::generate(jwk, hash_alg)?.kid;
-        let chall_token = oidc_chall.token;
-        let keyauth = format!("{chall_token}.{thumbprint}");
-
         let payload = Some(serde_json::json!({
             "id_token": id_token,
-            "keyauth": keyauth,
         }));
         let req = AcmeJws::new(alg, previous_nonce, &oidc_chall.url, Some(&acct_url), payload, kp)?;
         Ok(req)
@@ -136,9 +128,10 @@ pub enum AcmeChallengeType {
 
 #[cfg(test)]
 pub mod tests {
-    use super::*;
     use serde_json::json;
     use wasm_bindgen_test::*;
+
+    use super::*;
 
     wasm_bindgen_test_configure!(run_in_browser);
 

--- a/e2e-identity/Cargo.toml
+++ b/e2e-identity/Cargo.toml
@@ -57,13 +57,14 @@ pem = "3.0"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 rusty-acme = { version = "0.8.4", path = "../acme" }
-reqwest = { version = "0.11", features = ["json"], default_features = false }
+reqwest = { version = "0.11", features = ["json", "cookies"], default_features = false }
 tokio = { version = "1.5", features = ["macros"], default_features = false }
 hyper = { version = "0.14", features = ["server"], default_features = false }
 asserhttp = { version = "0.6", features = ["reqwest"] }
 testcontainers = "0.15"
 oauth2 = "4.3"
 http = "0.2"
+keycloak = "21"
 
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
 rusty-acme = { version = "0.8.4", path = "../acme" }

--- a/e2e-identity/README.md
+++ b/e2e-identity/README.md
@@ -11,34 +11,33 @@ sequenceDiagram
     acme-server->>-wire-client: 201
     wire-client->>+acme-server: 🔒 POST /acme/wire/new-order
     acme-server->>-wire-client: 201
-    wire-client->>+acme-server: 🔒 POST /acme/wire/authz/RO1lN0FiYIud1rZZ6E3uiY5eRdnjVE0o
+    wire-client->>+acme-server: 🔒 POST /acme/wire/authz/PQMMQsFRGJ63rw5BJXcZRW5gdxiAnfza
     acme-server->>-wire-client: 200
     wire-client->>+wire-server:  GET /clients/token/nonce
     wire-server->>-wire-client: 200
     wire-client->>wire-client: create DPoP token
-    wire-client->>+wire-server:  POST /clients/c7ddbab1a5225de1/access-token
+    wire-client->>+wire-server:  POST /clients/7f39900830740008/access-token
     wire-server->>-wire-client: 200
-    wire-client->>+acme-server: 🔒 POST /acme/wire/challenge/RO1lN0FiYIud1rZZ6E3uiY5eRdnjVE0o/0cSO2qsiV3grbpg9VN56vlr32RB4rLf4
+    wire-client->>+acme-server: 🔒 POST /acme/wire/challenge/PQMMQsFRGJ63rw5BJXcZRW5gdxiAnfza/xnRWBh033703AyPfEirQDytZggaHT2wt
     acme-server->>-wire-client: 200
     wire-client->>wire-client: OAUTH authorization request
-    wire-client->>+IdP:  GET /dex/auth
+    wire-client->>+IdP:  GET /realms/master/protocol/openid-connect/auth
     IdP->>-wire-client: 200
-    wire-client->>wire-client: OAUTH authorization code
-    wire-client->>+IdP:  POST /dex/token
+    wire-client->>+IdP:  POST /realms/master/protocol/openid-connect/token
     IdP->>-wire-client: 200
-    wire-client->>+acme-server: 🔒 POST /acme/wire/challenge/RO1lN0FiYIud1rZZ6E3uiY5eRdnjVE0o/nRHOLoqoWZHI6CGGORPT3ibdevmdUEz4
+    wire-client->>+acme-server: 🔒 POST /acme/wire/challenge/PQMMQsFRGJ63rw5BJXcZRW5gdxiAnfza/2G5CjoDyCVob9Nf6lhT1hwRSNcjflZML
     acme-server->>-wire-client: 200
-    wire-client->>+acme-server: 🔒 POST /acme/wire/order/aVU5mwC8z8tGZeRX1jmGtKGpl8CYKDrV
+    wire-client->>+acme-server: 🔒 POST /acme/wire/order/ThEcRXInIL8Z4W7f9S3pQDZ9QxaPISa2
     acme-server->>-wire-client: 200
-    wire-client->>+acme-server: 🔒 POST /acme/wire/order/aVU5mwC8z8tGZeRX1jmGtKGpl8CYKDrV/finalize
+    wire-client->>+acme-server: 🔒 POST /acme/wire/order/ThEcRXInIL8Z4W7f9S3pQDZ9QxaPISa2/finalize
     acme-server->>-wire-client: 200
-    wire-client->>+acme-server: 🔒 POST /acme/wire/certificate/iRBWw7qQq4v0vzo9sBGWya6v31jD5mRL
+    wire-client->>+acme-server: 🔒 POST /acme/wire/certificate/eN4Q9SLomOjJnA5YMDXNOHz7uRpMpg2t
     acme-server->>-wire-client: 200
 ```
 ### Initial setup with ACME server
 #### 1. fetch acme directory for hyperlinks
 ```http request
-GET https://stepca:32795/acme/wire/directory
+GET https://stepca:32900/acme/wire/directory
                         /acme/{acme-provisioner}/directory
 ```
 #### 2. get the ACME directory with links for newNonce, newAccount & newOrder
@@ -49,39 +48,39 @@ vary: Origin
 ```
 ```json
 {
-  "newNonce": "https://stepca:32795/acme/wire/new-nonce",
-  "newAccount": "https://stepca:32795/acme/wire/new-account",
-  "newOrder": "https://stepca:32795/acme/wire/new-order",
-  "revokeCert": "https://stepca:32795/acme/wire/revoke-cert"
+  "newNonce": "https://stepca:32900/acme/wire/new-nonce",
+  "newAccount": "https://stepca:32900/acme/wire/new-account",
+  "newOrder": "https://stepca:32900/acme/wire/new-order",
+  "revokeCert": "https://stepca:32900/acme/wire/revoke-cert"
 }
 ```
 #### 3. fetch a new nonce for the very first request
 ```http request
-HEAD https://stepca:32795/acme/wire/new-nonce
+HEAD https://stepca:32900/acme/wire/new-nonce
                          /acme/{acme-provisioner}/new-nonce
 ```
 #### 4. get a nonce for creating an account
 ```http request
 200
 cache-control: no-store
-link: <https://stepca:32795/acme/wire/directory>;rel="index"
-replay-nonce: MlhwTVZrOEgwN2xZTnZqQnRTR2dwVFlBdXNsSXQ4S0g
+link: <https://stepca:32900/acme/wire/directory>;rel="index"
+replay-nonce: WkVUUkR0VXg1NnAwMUpUcmxwYWZKMDBXaGw5dmkycHY
 vary: Origin
 ```
 ```text
-MlhwTVZrOEgwN2xZTnZqQnRTR2dwVFlBdXNsSXQ4S0g
+WkVUUkR0VXg1NnAwMUpUcmxwYWZKMDBXaGw5dmkycHY
 ```
 #### 5. create a new account
 ```http request
-POST https://stepca:32795/acme/wire/new-account
+POST https://stepca:32900/acme/wire/new-account
                          /acme/{acme-provisioner}/new-account
 content-type: application/jose+json
 ```
 ```json
 {
-  "protected": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsImp3ayI6eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6IjNXZzZEamJvWnpFZEZUdHRvVGlULWJTdUM5NzVQcWpxUlhZa2ZwU2tYbEEifSwibm9uY2UiOiJNbGh3VFZack9FZ3dOMnhaVG5acVFuUlRSMmR3VkZsQmRYTnNTWFE0UzBnIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI3OTUvYWNtZS93aXJlL25ldy1hY2NvdW50In0",
+  "protected": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsImp3ayI6eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6IjR1OFRPUG9SWi1GdUVIZ0RYeDNhT21aWmFWaUdSX190QzlPQXlJTHI1cWMifSwibm9uY2UiOiJXa1ZVVWtSMFZYZzFObkF3TVVwVWNteHdZV1pLTURCWGFHdzVkbWt5Y0hZIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI5MDAvYWNtZS93aXJlL25ldy1hY2NvdW50In0",
   "payload": "eyJ0ZXJtc09mU2VydmljZUFncmVlZCI6dHJ1ZSwiY29udGFjdCI6WyJhbm9ueW1vdXNAYW5vbnltb3VzLmludmFsaWQiXSwib25seVJldHVybkV4aXN0aW5nIjpmYWxzZX0",
-  "signature": "X2Wcwe2fe_X6qcfNBkiSrKUe2sjKk1gIipHQsg23qS4QbZ-osY0CwFCZF-l-azpNDjywFZ1HNPtwf-fxBtRmDg"
+  "signature": "_-ZVl_bdbtmGfY1jyzfRklOBunzQANuYVBJUSm6BSsAiex033mK7wHM2z3g6EfqBeJnejkU977EKO9qNORtqAQ"
 }
 ```
 ```json
@@ -98,11 +97,11 @@ content-type: application/jose+json
     "jwk": {
       "crv": "Ed25519",
       "kty": "OKP",
-      "x": "3Wg6DjboZzEdFTttoTiT-bSuC975PqjqRXYkfpSkXlA"
+      "x": "4u8TOPoRZ-FuEHgDXx3aOmZZaViGR__tC9OAyILr5qc"
     },
-    "nonce": "MlhwTVZrOEgwN2xZTnZqQnRTR2dwVFlBdXNsSXQ4S0g",
+    "nonce": "WkVUUkR0VXg1NnAwMUpUcmxwYWZKMDBXaGw5dmkycHY",
     "typ": "JWT",
-    "url": "https://stepca:32795/acme/wire/new-account"
+    "url": "https://stepca:32900/acme/wire/new-account"
   }
 }
 ```
@@ -111,29 +110,29 @@ content-type: application/jose+json
 201
 cache-control: no-store
 content-type: application/json
-link: <https://stepca:32795/acme/wire/directory>;rel="index"
-location: https://stepca:32795/acme/wire/account/Z9pcI6iMTzA1TELu1INslFx6EthReoVE
-replay-nonce: Z2ZIbVU4SEViM0ZZMzB1UmxramMxUG5ybnRpWGlJR0M
+link: <https://stepca:32900/acme/wire/directory>;rel="index"
+location: https://stepca:32900/acme/wire/account/gNNR5cLt7T81dtC2zzehEvQKu4LAYByz
+replay-nonce: aDJoV3JRWFVZQ0pzWDZiT1MyTEc5S2JyRmRxMXg0dzY
 vary: Origin
 ```
 ```json
 {
   "status": "valid",
-  "orders": "https://stepca:32795/acme/wire/account/Z9pcI6iMTzA1TELu1INslFx6EthReoVE/orders"
+  "orders": "https://stepca:32900/acme/wire/account/gNNR5cLt7T81dtC2zzehEvQKu4LAYByz/orders"
 }
 ```
 ### Request a certificate with relevant identifiers
 #### 7. create a new order
 ```http request
-POST https://stepca:32795/acme/wire/new-order
+POST https://stepca:32900/acme/wire/new-order
                          /acme/{acme-provisioner}/new-order
 content-type: application/jose+json
 ```
 ```json
 {
-  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMyNzk1L2FjbWUvd2lyZS9hY2NvdW50L1o5cGNJNmlNVHpBMVRFTHUxSU5zbEZ4NkV0aFJlb1ZFIiwidHlwIjoiSldUIiwibm9uY2UiOiJaMlpJYlZVNFNFVmlNMFpaTXpCMVVteHJhbU14VUc1eWJuUnBXR2xKUjBNIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI3OTUvYWNtZS93aXJlL25ldy1vcmRlciJ9",
-  "payload": "eyJpZGVudGlmaWVycyI6W3sidHlwZSI6IndpcmVhcHAtaWQiLCJ2YWx1ZSI6IntcIm5hbWVcIjpcIkFsaWNlIFNtaXRoXCIsXCJkb21haW5cIjpcIndpcmUuY29tXCIsXCJjbGllbnQtaWRcIjpcIndpcmVhcHA6Ly9JUjBfSU10Q1RMaTNhczVFb0NCd1hnIWM3ZGRiYWIxYTUyMjVkZTFAd2lyZS5jb21cIixcImhhbmRsZVwiOlwid2lyZWFwcDovLyU0MGFsaWNlX3dpcmVAd2lyZS5jb21cIn0ifV0sIm5vdEJlZm9yZSI6IjIwMjQtMDEtMTVUMTY6Mjc6MjkuMjMzNzI1WiIsIm5vdEFmdGVyIjoiMjAzNC0wMS0xMlQxNjoyNzoyOS4yMzM3MjVaIn0",
-  "signature": "oKj1BZSyGxh-FpUY5b0VabgM_NW27BR4pxkzSG-w2NEsUJt3YU0cVRuPmh2J2DNyQOFFV02qraIcgDGnh_X_Dw"
+  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMyOTAwL2FjbWUvd2lyZS9hY2NvdW50L2dOTlI1Y0x0N1Q4MWR0QzJ6emVoRXZRS3U0TEFZQnl6IiwidHlwIjoiSldUIiwibm9uY2UiOiJhREpvVjNKUldGVlpRMHB6V0RaaVQxTXlURWM1UzJKeVJtUnhNWGcwZHpZIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI5MDAvYWNtZS93aXJlL25ldy1vcmRlciJ9",
+  "payload": "eyJpZGVudGlmaWVycyI6W3sidHlwZSI6IndpcmVhcHAtaWQiLCJ2YWx1ZSI6IntcIm5hbWVcIjpcIkFsaWNlIFNtaXRoXCIsXCJkb21haW5cIjpcIndpcmUuY29tXCIsXCJjbGllbnQtaWRcIjpcIndpcmVhcHA6Ly9xSGlETHNia1QyLXA5dVNKc21yWl9BITdmMzk5MDA4MzA3NDAwMDhAd2lyZS5jb21cIixcImhhbmRsZVwiOlwid2lyZWFwcDovLyU0MGFsaWNlX3dpcmVAd2lyZS5jb21cIn0ifV0sIm5vdEJlZm9yZSI6IjIwMjQtMDEtMTZUMTU6MDk6MjAuNDA0Mzg5WiIsIm5vdEFmdGVyIjoiMjAzNC0wMS0xM1QxNTowOToyMC40MDQzODlaIn0",
+  "signature": "Bil4llgYBB1UiTCymbt5vv6SEZ1VefF9UkBf7-0rZjoL1mdLibyCdCnseegQ1rpnAGOgztfQHXd3q8Xll2Q3BQ"
 }
 ```
 ```json
@@ -142,18 +141,18 @@ content-type: application/jose+json
     "identifiers": [
       {
         "type": "wireapp-id",
-        "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"wireapp://IR0_IMtCTLi3as5EoCBwXg!c7ddbab1a5225de1@wire.com\",\"handle\":\"wireapp://%40alice_wire@wire.com\"}"
+        "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"wireapp://qHiDLsbkT2-p9uSJsmrZ_A!7f39900830740008@wire.com\",\"handle\":\"wireapp://%40alice_wire@wire.com\"}"
       }
     ],
-    "notAfter": "2034-01-12T16:27:29.233725Z",
-    "notBefore": "2024-01-15T16:27:29.233725Z"
+    "notAfter": "2034-01-13T15:09:20.404389Z",
+    "notBefore": "2024-01-16T15:09:20.404389Z"
   },
   "protected": {
     "alg": "EdDSA",
-    "kid": "https://stepca:32795/acme/wire/account/Z9pcI6iMTzA1TELu1INslFx6EthReoVE",
-    "nonce": "Z2ZIbVU4SEViM0ZZMzB1UmxramMxUG5ybnRpWGlJR0M",
+    "kid": "https://stepca:32900/acme/wire/account/gNNR5cLt7T81dtC2zzehEvQKu4LAYByz",
+    "nonce": "aDJoV3JRWFVZQ0pzWDZiT1MyTEc5S2JyRmRxMXg0dzY",
     "typ": "JWT",
-    "url": "https://stepca:32795/acme/wire/new-order"
+    "url": "https://stepca:32900/acme/wire/new-order"
   }
 }
 ```
@@ -162,41 +161,41 @@ content-type: application/jose+json
 201
 cache-control: no-store
 content-type: application/json
-link: <https://stepca:32795/acme/wire/directory>;rel="index"
-location: https://stepca:32795/acme/wire/order/aVU5mwC8z8tGZeRX1jmGtKGpl8CYKDrV
-replay-nonce: SmdsY2k2c1J4OTVGQ3F4SHc4UXR2M3BQNEJPR3ZGVU0
+link: <https://stepca:32900/acme/wire/directory>;rel="index"
+location: https://stepca:32900/acme/wire/order/ThEcRXInIL8Z4W7f9S3pQDZ9QxaPISa2
+replay-nonce: b3JMcGFjVW10WktzSFRZWWUxZG1ja2w4WFZQTDdoNFY
 vary: Origin
 ```
 ```json
 {
   "status": "pending",
-  "finalize": "https://stepca:32795/acme/wire/order/aVU5mwC8z8tGZeRX1jmGtKGpl8CYKDrV/finalize",
+  "finalize": "https://stepca:32900/acme/wire/order/ThEcRXInIL8Z4W7f9S3pQDZ9QxaPISa2/finalize",
   "identifiers": [
     {
       "type": "wireapp-id",
-      "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"wireapp://IR0_IMtCTLi3as5EoCBwXg!c7ddbab1a5225de1@wire.com\",\"handle\":\"wireapp://%40alice_wire@wire.com\"}"
+      "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"wireapp://qHiDLsbkT2-p9uSJsmrZ_A!7f39900830740008@wire.com\",\"handle\":\"wireapp://%40alice_wire@wire.com\"}"
     }
   ],
   "authorizations": [
-    "https://stepca:32795/acme/wire/authz/RO1lN0FiYIud1rZZ6E3uiY5eRdnjVE0o"
+    "https://stepca:32900/acme/wire/authz/PQMMQsFRGJ63rw5BJXcZRW5gdxiAnfza"
   ],
-  "expires": "2024-01-16T16:27:29Z",
-  "notBefore": "2024-01-15T16:27:29.233725Z",
-  "notAfter": "2034-01-12T16:27:29.233725Z"
+  "expires": "2024-01-17T15:09:20Z",
+  "notBefore": "2024-01-16T15:09:20.404389Z",
+  "notAfter": "2034-01-13T15:09:20.404389Z"
 }
 ```
 ### Display-name and handle already authorized
 #### 9. create authorization and fetch challenges
 ```http request
-POST https://stepca:32795/acme/wire/authz/RO1lN0FiYIud1rZZ6E3uiY5eRdnjVE0o
+POST https://stepca:32900/acme/wire/authz/PQMMQsFRGJ63rw5BJXcZRW5gdxiAnfza
                          /acme/{acme-provisioner}/authz/{authz-id}
 content-type: application/jose+json
 ```
 ```json
 {
-  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMyNzk1L2FjbWUvd2lyZS9hY2NvdW50L1o5cGNJNmlNVHpBMVRFTHUxSU5zbEZ4NkV0aFJlb1ZFIiwidHlwIjoiSldUIiwibm9uY2UiOiJTbWRzWTJrMmMxSjRPVFZHUTNGNFNIYzRVWFIyTTNCUU5FSlBSM1pHVlUwIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI3OTUvYWNtZS93aXJlL2F1dGh6L1JPMWxOMEZpWUl1ZDFyWlo2RTN1aVk1ZVJkbmpWRTBvIn0",
+  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMyOTAwL2FjbWUvd2lyZS9hY2NvdW50L2dOTlI1Y0x0N1Q4MWR0QzJ6emVoRXZRS3U0TEFZQnl6IiwidHlwIjoiSldUIiwibm9uY2UiOiJiM0pNY0dGalZXMTBXa3R6U0ZSWldXVXhaRzFqYTJ3NFdGWlFURGRvTkZZIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI5MDAvYWNtZS93aXJlL2F1dGh6L1BRTU1Rc0ZSR0o2M3J3NUJKWGNaUlc1Z2R4aUFuZnphIn0",
   "payload": "",
-  "signature": "Bm1OjB1JS-BCrmpQpSyVxG4Jb7lScCO0SVQTjqpcHsmS5R3kPh1jPM0qYlHb3ZE8Ot50J2kPdj1W1g5yH9zmDQ"
+  "signature": "7fTpp1fhxmS8domTi7GaGl_gOGTI7pFpI_KQJHp2Srm4UiOqJwwoRvHqNmOn5M_EdhylnxjB9jLtZTUTHmhPBA"
 }
 ```
 ```json
@@ -204,10 +203,10 @@ content-type: application/jose+json
   "payload": {},
   "protected": {
     "alg": "EdDSA",
-    "kid": "https://stepca:32795/acme/wire/account/Z9pcI6iMTzA1TELu1INslFx6EthReoVE",
-    "nonce": "SmdsY2k2c1J4OTVGQ3F4SHc4UXR2M3BQNEJPR3ZGVU0",
+    "kid": "https://stepca:32900/acme/wire/account/gNNR5cLt7T81dtC2zzehEvQKu4LAYByz",
+    "nonce": "b3JMcGFjVW10WktzSFRZWWUxZG1ja2w4WFZQTDdoNFY",
     "typ": "JWT",
-    "url": "https://stepca:32795/acme/wire/authz/RO1lN0FiYIud1rZZ6E3uiY5eRdnjVE0o"
+    "url": "https://stepca:32900/acme/wire/authz/PQMMQsFRGJ63rw5BJXcZRW5gdxiAnfza"
   }
 }
 ```
@@ -216,41 +215,41 @@ content-type: application/jose+json
 200
 cache-control: no-store
 content-type: application/json
-link: <https://stepca:32795/acme/wire/directory>;rel="index"
-location: https://stepca:32795/acme/wire/authz/RO1lN0FiYIud1rZZ6E3uiY5eRdnjVE0o
-replay-nonce: b3NIR3J1bkt3aUpBd3g5eHVoZ003SW9EZjlUNmp2ekE
+link: <https://stepca:32900/acme/wire/directory>;rel="index"
+location: https://stepca:32900/acme/wire/authz/PQMMQsFRGJ63rw5BJXcZRW5gdxiAnfza
+replay-nonce: ZzhkVmRwODVRdmhFakZJRlBRdUFTNGhwOER6eXFCdE4
 vary: Origin
 ```
 ```json
 {
   "status": "pending",
-  "expires": "2024-01-16T16:27:29Z",
+  "expires": "2024-01-17T15:09:20Z",
   "challenges": [
     {
       "type": "wire-oidc-01",
-      "url": "https://stepca:32795/acme/wire/challenge/RO1lN0FiYIud1rZZ6E3uiY5eRdnjVE0o/nRHOLoqoWZHI6CGGORPT3ibdevmdUEz4",
+      "url": "https://stepca:32900/acme/wire/challenge/PQMMQsFRGJ63rw5BJXcZRW5gdxiAnfza/2G5CjoDyCVob9Nf6lhT1hwRSNcjflZML",
       "status": "pending",
-      "token": "25xCjZl0wgv1jCU4Iu6HdtosB6yYvuSc",
-      "target": "http://dex:21126/dex"
+      "token": "J65uIAsUjdJvNF0Frf7lyPlO7hlDGnWh",
+      "target": "http://keycloak:23675/realms/master"
     },
     {
       "type": "wire-dpop-01",
-      "url": "https://stepca:32795/acme/wire/challenge/RO1lN0FiYIud1rZZ6E3uiY5eRdnjVE0o/0cSO2qsiV3grbpg9VN56vlr32RB4rLf4",
+      "url": "https://stepca:32900/acme/wire/challenge/PQMMQsFRGJ63rw5BJXcZRW5gdxiAnfza/xnRWBh033703AyPfEirQDytZggaHT2wt",
       "status": "pending",
-      "token": "25xCjZl0wgv1jCU4Iu6HdtosB6yYvuSc",
-      "target": "http://wire.com:22504/clients/c7ddbab1a5225de1/access-token"
+      "token": "J65uIAsUjdJvNF0Frf7lyPlO7hlDGnWh",
+      "target": "http://wire.com:19803/clients/7f39900830740008/access-token"
     }
   ],
   "identifier": {
     "type": "wireapp-id",
-    "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"wireapp://IR0_IMtCTLi3as5EoCBwXg!c7ddbab1a5225de1@wire.com\",\"handle\":\"wireapp://%40alice_wire@wire.com\"}"
+    "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"wireapp://qHiDLsbkT2-p9uSJsmrZ_A!7f39900830740008@wire.com\",\"handle\":\"wireapp://%40alice_wire@wire.com\"}"
   }
 }
 ```
 ### Client fetches JWT DPoP access token (with wire-server)
 #### 11. fetch a nonce from wire-server
 ```http request
-GET http://wire.com:22504/clients/token/nonce
+GET http://wire.com:19803/clients/token/nonce
 ```
 #### 12. get wire-server nonce
 ```http request
@@ -258,7 +257,7 @@ GET http://wire.com:22504/clients/token/nonce
 
 ```
 ```text
-b0tVOGw5dkpxcDFabWNnWEJBck5keUN2R3RzRUtLdjk
+SnpzWUZaVXZxa0pGYkJRUzBKOGw5Q0xFMGRQbzFmVTQ
 ```
 #### 13. create client DPoP token
 
@@ -266,23 +265,23 @@ b0tVOGw5dkpxcDFabWNnWEJBck5keUN2R3RzRUtLdjk
 <details>
 <summary><b>Dpop token</b></summary>
 
-See it on [jwt.io](https://jwt.io/#id_token=eyJhbGciOiJFZERTQSIsInR5cCI6ImRwb3Arand0IiwiandrIjp7Imt0eSI6Ik9LUCIsImNydiI6IkVkMjU1MTkiLCJ4IjoiM1dnNkRqYm9aekVkRlR0dG9UaVQtYlN1Qzk3NVBxanFSWFlrZnBTa1hsQSJ9fQ.eyJpYXQiOjE3MDUzMzI0NDksImV4cCI6MTcwNTMzOTY0OSwibmJmIjoxNzA1MzMyNDQ5LCJzdWIiOiJ3aXJlYXBwOi8vSVIwX0lNdENUTGkzYXM1RW9DQndYZyFjN2RkYmFiMWE1MjI1ZGUxQHdpcmUuY29tIiwianRpIjoiYzhhODU4Y2YtODQzZi00NGRjLWFmZmYtNzVkMDEyZmMzZjNlIiwibm9uY2UiOiJiMHRWT0d3NWRrcHhjREZhYldObldFSkJjazVrZVVOMlIzUnpSVXRMZGprIiwiaHRtIjoiUE9TVCIsImh0dSI6Imh0dHA6Ly93aXJlLmNvbToyMjUwNC9jbGllbnRzL2M3ZGRiYWIxYTUyMjVkZTEvYWNjZXNzLXRva2VuIiwiY2hhbCI6IjI1eENqWmwwd2d2MWpDVTRJdTZIZHRvc0I2eVl2dVNjIiwiaGFuZGxlIjoid2lyZWFwcDovLyU0MGFsaWNlX3dpcmVAd2lyZS5jb20iLCJ0ZWFtIjoid2lyZSJ9.MxVAvDCKEGirsVsuBSy8CR2QJScskGliZ7L7EjqOzYJlt86-SXQ8g-JJKFkHWkos_tmUo4KeN5AWermww2wYDg)
+See it on [jwt.io](https://jwt.io/#id_token=eyJhbGciOiJFZERTQSIsInR5cCI6ImRwb3Arand0IiwiandrIjp7Imt0eSI6Ik9LUCIsImNydiI6IkVkMjU1MTkiLCJ4IjoiNHU4VE9Qb1JaLUZ1RUhnRFh4M2FPbVpaYVZpR1JfX3RDOU9BeUlMcjVxYyJ9fQ.eyJpYXQiOjE3MDU0MTQxNjAsImV4cCI6MTcwNTQyMTM2MCwibmJmIjoxNzA1NDE0MTYwLCJzdWIiOiJ3aXJlYXBwOi8vcUhpRExzYmtUMi1wOXVTSnNtclpfQSE3ZjM5OTAwODMwNzQwMDA4QHdpcmUuY29tIiwianRpIjoiZTg2MTRhOGItMDAxNi00ZjFkLTg1ZGYtZjJiN2U1OGZhNTk2Iiwibm9uY2UiOiJTbnB6V1VaYVZYWnhhMHBHWWtKUlV6QktPR3c1UTB4Rk1HUlFiekZtVlRRIiwiaHRtIjoiUE9TVCIsImh0dSI6Imh0dHA6Ly93aXJlLmNvbToxOTgwMy9jbGllbnRzLzdmMzk5MDA4MzA3NDAwMDgvYWNjZXNzLXRva2VuIiwiY2hhbCI6Iko2NXVJQXNVamRKdk5GMEZyZjdseVBsTzdobERHbldoIiwiaGFuZGxlIjoid2lyZWFwcDovLyU0MGFsaWNlX3dpcmVAd2lyZS5jb20iLCJ0ZWFtIjoid2lyZSJ9.4EDHws9_reRkRTBZbjSai0RPwgTQ_dTo1_ZLceyXnFTXuCxn23X8nALehe2wprP7eFeXQIksFgMAI2Bql9irBg)
 
 Raw:
 ```text
 eyJhbGciOiJFZERTQSIsInR5cCI6ImRwb3Arand0IiwiandrIjp7Imt0eSI6Ik9L
-UCIsImNydiI6IkVkMjU1MTkiLCJ4IjoiM1dnNkRqYm9aekVkRlR0dG9UaVQtYlN1
-Qzk3NVBxanFSWFlrZnBTa1hsQSJ9fQ.eyJpYXQiOjE3MDUzMzI0NDksImV4cCI6M
-TcwNTMzOTY0OSwibmJmIjoxNzA1MzMyNDQ5LCJzdWIiOiJ3aXJlYXBwOi8vSVIwX
-0lNdENUTGkzYXM1RW9DQndYZyFjN2RkYmFiMWE1MjI1ZGUxQHdpcmUuY29tIiwia
-nRpIjoiYzhhODU4Y2YtODQzZi00NGRjLWFmZmYtNzVkMDEyZmMzZjNlIiwibm9uY
-2UiOiJiMHRWT0d3NWRrcHhjREZhYldObldFSkJjazVrZVVOMlIzUnpSVXRMZGprI
-iwiaHRtIjoiUE9TVCIsImh0dSI6Imh0dHA6Ly93aXJlLmNvbToyMjUwNC9jbGllb
-nRzL2M3ZGRiYWIxYTUyMjVkZTEvYWNjZXNzLXRva2VuIiwiY2hhbCI6IjI1eENqW
-mwwd2d2MWpDVTRJdTZIZHRvc0I2eVl2dVNjIiwiaGFuZGxlIjoid2lyZWFwcDovL
-yU0MGFsaWNlX3dpcmVAd2lyZS5jb20iLCJ0ZWFtIjoid2lyZSJ9.MxVAvDCKEGir
-sVsuBSy8CR2QJScskGliZ7L7EjqOzYJlt86-SXQ8g-JJKFkHWkos_tmUo4KeN5AW
-ermww2wYDg
+UCIsImNydiI6IkVkMjU1MTkiLCJ4IjoiNHU4VE9Qb1JaLUZ1RUhnRFh4M2FPbVpa
+YVZpR1JfX3RDOU9BeUlMcjVxYyJ9fQ.eyJpYXQiOjE3MDU0MTQxNjAsImV4cCI6M
+TcwNTQyMTM2MCwibmJmIjoxNzA1NDE0MTYwLCJzdWIiOiJ3aXJlYXBwOi8vcUhpR
+ExzYmtUMi1wOXVTSnNtclpfQSE3ZjM5OTAwODMwNzQwMDA4QHdpcmUuY29tIiwia
+nRpIjoiZTg2MTRhOGItMDAxNi00ZjFkLTg1ZGYtZjJiN2U1OGZhNTk2Iiwibm9uY
+2UiOiJTbnB6V1VaYVZYWnhhMHBHWWtKUlV6QktPR3c1UTB4Rk1HUlFiekZtVlRRI
+iwiaHRtIjoiUE9TVCIsImh0dSI6Imh0dHA6Ly93aXJlLmNvbToxOTgwMy9jbGllb
+nRzLzdmMzk5MDA4MzA3NDAwMDgvYWNjZXNzLXRva2VuIiwiY2hhbCI6Iko2NXVJQ
+XNVamRKdk5GMEZyZjdseVBsTzdobERHbldoIiwiaGFuZGxlIjoid2lyZWFwcDovL
+yU0MGFsaWNlX3dpcmVAd2lyZS5jb20iLCJ0ZWFtIjoid2lyZSJ9.4EDHws9_reRk
+RTBZbjSai0RPwgTQ_dTo1_ZLceyXnFTXuCxn23X8nALehe2wprP7eFeXQIksFgMA
+I2Bql9irBg
 ```
 
 Decoded:
@@ -293,7 +292,7 @@ Decoded:
   "jwk": {
     "crv": "Ed25519",
     "kty": "OKP",
-    "x": "3Wg6DjboZzEdFTttoTiT-bSuC975PqjqRXYkfpSkXlA"
+    "x": "4u8TOPoRZ-FuEHgDXx3aOmZZaViGR__tC9OAyILr5qc"
   },
   "typ": "dpop+jwt"
 }
@@ -301,16 +300,16 @@ Decoded:
 
 ```json
 {
-  "chal": "25xCjZl0wgv1jCU4Iu6HdtosB6yYvuSc",
-  "exp": 1705339649,
+  "chal": "J65uIAsUjdJvNF0Frf7lyPlO7hlDGnWh",
+  "exp": 1705421360,
   "handle": "wireapp://%40alice_wire@wire.com",
   "htm": "POST",
-  "htu": "http://wire.com:22504/clients/c7ddbab1a5225de1/access-token",
-  "iat": 1705332449,
-  "jti": "c8a858cf-843f-44dc-afff-75d012fc3f3e",
-  "nbf": 1705332449,
-  "nonce": "b0tVOGw5dkpxcDFabWNnWEJBck5keUN2R3RzRUtLdjk",
-  "sub": "wireapp://IR0_IMtCTLi3as5EoCBwXg!c7ddbab1a5225de1@wire.com",
+  "htu": "http://wire.com:19803/clients/7f39900830740008/access-token",
+  "iat": 1705414160,
+  "jti": "e8614a8b-0016-4f1d-85df-f2b7e58fa596",
+  "nbf": 1705414160,
+  "nonce": "SnpzWUZaVXZxa0pGYkJRUzBKOGw5Q0xFMGRQbzFmVTQ",
+  "sub": "wireapp://qHiDLsbkT2-p9uSJsmrZ_A!7f39900830740008@wire.com",
   "team": "wire"
 }
 ```
@@ -319,10 +318,10 @@ Decoded:
 ✅ Signature Verified with key:
 ```text
 -----BEGIN PRIVATE KEY-----
-MC4CAQAwBQYDK2VwBCIEIC2cE83MfmM/IqOCWPFNBnzNnLbYkQF6MDu6RK/5VYWI
+MC4CAQAwBQYDK2VwBCIEIN8QTftdDNtQqC6IZAsvVpmfFIiHVe7mbBrKFlr11Xgi
 -----END PRIVATE KEY-----
 -----BEGIN PUBLIC KEY-----
-MCowBQYDK2VwAyEA3Wg6DjboZzEdFTttoTiT+bSuC975PqjqRXYkfpSkXlA=
+MCowBQYDK2VwAyEA4u8TOPoRZ+FuEHgDXx3aOmZZaViGR//tC9OAyILr5qc=
 -----END PUBLIC KEY-----
 ```
 
@@ -331,9 +330,9 @@ MCowBQYDK2VwAyEA3Wg6DjboZzEdFTttoTiT+bSuC975PqjqRXYkfpSkXlA=
 
 #### 14. trade client DPoP token for an access token
 ```http request
-POST http://wire.com:22504/clients/c7ddbab1a5225de1/access-token
+POST http://wire.com:19803/clients/7f39900830740008/access-token
                           /clients/{device-id}/access-token
-dpop: ZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNkltUndiM0FyYW5kMElpd2lhbmRySWpwN0ltdDBlU0k2SWs5TFVDSXNJbU55ZGlJNklrVmtNalUxTVRraUxDSjRJam9pTTFkbk5rUnFZbTlhZWtWa1JsUjBkRzlVYVZRdFlsTjFRemszTlZCeGFuRlNXRmxyWm5CVGExaHNRU0o5ZlEuZXlKcFlYUWlPakUzTURVek16STBORGtzSW1WNGNDSTZNVGN3TlRNek9UWTBPU3dpYm1KbUlqb3hOekExTXpNeU5EUTVMQ0p6ZFdJaU9pSjNhWEpsWVhCd09pOHZTVkl3WDBsTmRFTlVUR2t6WVhNMVJXOURRbmRZWnlGak4yUmtZbUZpTVdFMU1qSTFaR1V4UUhkcGNtVXVZMjl0SWl3aWFuUnBJam9pWXpoaE9EVTRZMll0T0RRelppMDBOR1JqTFdGbVptWXROelZrTURFeVptTXpaak5sSWl3aWJtOXVZMlVpT2lKaU1IUldUMGQzTldScmNIaGpSRVpoWWxkT2JsZEZTa0pqYXpWclpWVk9NbEl6VW5wU1ZYUk1aR3BySWl3aWFIUnRJam9pVUU5VFZDSXNJbWgwZFNJNkltaDBkSEE2THk5M2FYSmxMbU52YlRveU1qVXdOQzlqYkdsbGJuUnpMMk0zWkdSaVlXSXhZVFV5TWpWa1pURXZZV05qWlhOekxYUnZhMlZ1SWl3aVkyaGhiQ0k2SWpJMWVFTnFXbXd3ZDJkMk1XcERWVFJKZFRaSVpIUnZjMEkyZVZsMmRWTmpJaXdpYUdGdVpHeGxJam9pZDJseVpXRndjRG92THlVME1HRnNhV05sWDNkcGNtVkFkMmx5WlM1amIyMGlMQ0owWldGdElqb2lkMmx5WlNKOS5NeFZBdkRDS0VHaXJzVnN1QlN5OENSMlFKU2Nza0dsaVo3TDdFanFPellKbHQ4Ni1TWFE4Zy1KSktGa0hXa29zX3RtVW80S2VONUFXZXJtd3cyd1lEZw
+dpop: ZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNkltUndiM0FyYW5kMElpd2lhbmRySWpwN0ltdDBlU0k2SWs5TFVDSXNJbU55ZGlJNklrVmtNalUxTVRraUxDSjRJam9pTkhVNFZFOVFiMUphTFVaMVJVaG5SRmg0TTJGUGJWcGFZVlpwUjFKZlgzUkRPVTlCZVVsTWNqVnhZeUo5ZlEuZXlKcFlYUWlPakUzTURVME1UUXhOakFzSW1WNGNDSTZNVGN3TlRReU1UTTJNQ3dpYm1KbUlqb3hOekExTkRFME1UWXdMQ0p6ZFdJaU9pSjNhWEpsWVhCd09pOHZjVWhwUkV4elltdFVNaTF3T1hWVFNuTnRjbHBmUVNFM1pqTTVPVEF3T0RNd056UXdNREE0UUhkcGNtVXVZMjl0SWl3aWFuUnBJam9pWlRnMk1UUmhPR0l0TURBeE5pMDBaakZrTFRnMVpHWXRaakppTjJVMU9HWmhOVGsySWl3aWJtOXVZMlVpT2lKVGJuQjZWMVZhWVZaWVduaGhNSEJIV1d0S1VsVjZRa3RQUjNjMVVUQjRSazFIVWxGaWVrWnRWbFJSSWl3aWFIUnRJam9pVUU5VFZDSXNJbWgwZFNJNkltaDBkSEE2THk5M2FYSmxMbU52YlRveE9UZ3dNeTlqYkdsbGJuUnpMemRtTXprNU1EQTRNekEzTkRBd01EZ3ZZV05qWlhOekxYUnZhMlZ1SWl3aVkyaGhiQ0k2SWtvMk5YVkpRWE5WYW1SS2RrNUdNRVp5Wmpkc2VWQnNUemRvYkVSSGJsZG9JaXdpYUdGdVpHeGxJam9pZDJseVpXRndjRG92THlVME1HRnNhV05sWDNkcGNtVkFkMmx5WlM1amIyMGlMQ0owWldGdElqb2lkMmx5WlNKOS40RURId3M5X3JlUmtSVEJaYmpTYWkwUlB3Z1RRX2RUbzFfWkxjZXlYbkZUWHVDeG4yM1g4bkFMZWhlMndwclA3ZUZlWFFJa3NGZ01BSTJCcWw5aXJCZw
 ```
 #### 15. get a Dpop access token from wire-server
 ```http request
@@ -343,7 +342,7 @@ dpop: ZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNkltUndiM0FyYW5kMElpd2lhbmRySWpwN0ltdD
 ```json
 {
   "expires_in": 2082008461,
-  "token": "eyJhbGciOiJFZERTQSIsInR5cCI6ImF0K2p3dCIsImp3ayI6eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6IjlydDJMVHVyeTRJQTFZZExVYU4zT1JYUzRtZVlZTmhybWMtcXVYWUcxQjAifX0.eyJpYXQiOjE3MDUzMzI0NDksImV4cCI6MTcwNTMzNjQwOSwibmJmIjoxNzA1MzMyNDQ5LCJpc3MiOiJodHRwOi8vd2lyZS5jb206MjI1MDQvY2xpZW50cy9jN2RkYmFiMWE1MjI1ZGUxL2FjY2Vzcy10b2tlbiIsInN1YiI6IndpcmVhcHA6Ly9JUjBfSU10Q1RMaTNhczVFb0NCd1hnIWM3ZGRiYWIxYTUyMjVkZTFAd2lyZS5jb20iLCJhdWQiOiJodHRwOi8vd2lyZS5jb206MjI1MDQvY2xpZW50cy9jN2RkYmFiMWE1MjI1ZGUxL2FjY2Vzcy10b2tlbiIsImp0aSI6ImI0N2MwYmFlLWM1OGMtNGI3ZC05YTA0LTVhNWFkMWVlMDhjYiIsIm5vbmNlIjoiYjB0Vk9HdzVka3B4Y0RGYWJXTm5XRUpCY2s1a2VVTjJSM1J6UlV0TGRqayIsImNoYWwiOiIyNXhDalpsMHdndjFqQ1U0SXU2SGR0b3NCNnlZdnVTYyIsImNuZiI6eyJraWQiOiJTU3htTVBJanhaWC1lRHhBa1JreDhjWEpoRE1XUlRHTGhGNXV5VmVqUDRvIn0sInByb29mIjoiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNkltUndiM0FyYW5kMElpd2lhbmRySWpwN0ltdDBlU0k2SWs5TFVDSXNJbU55ZGlJNklrVmtNalUxTVRraUxDSjRJam9pTTFkbk5rUnFZbTlhZWtWa1JsUjBkRzlVYVZRdFlsTjFRemszTlZCeGFuRlNXRmxyWm5CVGExaHNRU0o5ZlEuZXlKcFlYUWlPakUzTURVek16STBORGtzSW1WNGNDSTZNVGN3TlRNek9UWTBPU3dpYm1KbUlqb3hOekExTXpNeU5EUTVMQ0p6ZFdJaU9pSjNhWEpsWVhCd09pOHZTVkl3WDBsTmRFTlVUR2t6WVhNMVJXOURRbmRZWnlGak4yUmtZbUZpTVdFMU1qSTFaR1V4UUhkcGNtVXVZMjl0SWl3aWFuUnBJam9pWXpoaE9EVTRZMll0T0RRelppMDBOR1JqTFdGbVptWXROelZrTURFeVptTXpaak5sSWl3aWJtOXVZMlVpT2lKaU1IUldUMGQzTldScmNIaGpSRVpoWWxkT2JsZEZTa0pqYXpWclpWVk9NbEl6VW5wU1ZYUk1aR3BySWl3aWFIUnRJam9pVUU5VFZDSXNJbWgwZFNJNkltaDBkSEE2THk5M2FYSmxMbU52YlRveU1qVXdOQzlqYkdsbGJuUnpMMk0zWkdSaVlXSXhZVFV5TWpWa1pURXZZV05qWlhOekxYUnZhMlZ1SWl3aVkyaGhiQ0k2SWpJMWVFTnFXbXd3ZDJkMk1XcERWVFJKZFRaSVpIUnZjMEkyZVZsMmRWTmpJaXdpYUdGdVpHeGxJam9pZDJseVpXRndjRG92THlVME1HRnNhV05sWDNkcGNtVkFkMmx5WlM1amIyMGlMQ0owWldGdElqb2lkMmx5WlNKOS5NeFZBdkRDS0VHaXJzVnN1QlN5OENSMlFKU2Nza0dsaVo3TDdFanFPellKbHQ4Ni1TWFE4Zy1KSktGa0hXa29zX3RtVW80S2VONUFXZXJtd3cyd1lEZyIsImNsaWVudF9pZCI6IndpcmVhcHA6Ly9JUjBfSU10Q1RMaTNhczVFb0NCd1hnIWM3ZGRiYWIxYTUyMjVkZTFAd2lyZS5jb20iLCJhcGlfdmVyc2lvbiI6NSwic2NvcGUiOiJ3aXJlX2NsaWVudF9pZCJ9.gn9AhrsnwaVKLnSCg3SAlClc37Ywj85Uz8P3uMlO_mpw6HUAKEkPBMMunSfnhwd3tCiynne5_u4HBcVD3HwiAA",
+  "token": "eyJhbGciOiJFZERTQSIsInR5cCI6ImF0K2p3dCIsImp3ayI6eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Imhnbzl1SGEwNTg4bWsxM3F0bzZBMzl6Yk0xOW92OVk4SjRPSnVTLVZWQncifX0.eyJpYXQiOjE3MDU0MTQxNjAsImV4cCI6MTcwNTQxODEyMCwibmJmIjoxNzA1NDE0MTYwLCJpc3MiOiJodHRwOi8vd2lyZS5jb206MTk4MDMvY2xpZW50cy83ZjM5OTAwODMwNzQwMDA4L2FjY2Vzcy10b2tlbiIsInN1YiI6IndpcmVhcHA6Ly9xSGlETHNia1QyLXA5dVNKc21yWl9BITdmMzk5MDA4MzA3NDAwMDhAd2lyZS5jb20iLCJhdWQiOiJodHRwOi8vd2lyZS5jb206MTk4MDMvY2xpZW50cy83ZjM5OTAwODMwNzQwMDA4L2FjY2Vzcy10b2tlbiIsImp0aSI6IjA4NWZiNWJjLTQ5OWUtNDFlMi1iZTJjLWY2ZTQxOWUxODgzMSIsIm5vbmNlIjoiU25weldVWmFWWFp4YTBwR1lrSlJVekJLT0d3NVEweEZNR1JRYnpGbVZUUSIsImNoYWwiOiJKNjV1SUFzVWpkSnZORjBGcmY3bHlQbE83aGxER25XaCIsImNuZiI6eyJraWQiOiI2QXl3V21OVER5Q3hXRzdZSkF6M2tSeGVjZUEtdDJYbm1UMHR3QUpKYmowIn0sInByb29mIjoiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNkltUndiM0FyYW5kMElpd2lhbmRySWpwN0ltdDBlU0k2SWs5TFVDSXNJbU55ZGlJNklrVmtNalUxTVRraUxDSjRJam9pTkhVNFZFOVFiMUphTFVaMVJVaG5SRmg0TTJGUGJWcGFZVlpwUjFKZlgzUkRPVTlCZVVsTWNqVnhZeUo5ZlEuZXlKcFlYUWlPakUzTURVME1UUXhOakFzSW1WNGNDSTZNVGN3TlRReU1UTTJNQ3dpYm1KbUlqb3hOekExTkRFME1UWXdMQ0p6ZFdJaU9pSjNhWEpsWVhCd09pOHZjVWhwUkV4elltdFVNaTF3T1hWVFNuTnRjbHBmUVNFM1pqTTVPVEF3T0RNd056UXdNREE0UUhkcGNtVXVZMjl0SWl3aWFuUnBJam9pWlRnMk1UUmhPR0l0TURBeE5pMDBaakZrTFRnMVpHWXRaakppTjJVMU9HWmhOVGsySWl3aWJtOXVZMlVpT2lKVGJuQjZWMVZhWVZaWVduaGhNSEJIV1d0S1VsVjZRa3RQUjNjMVVUQjRSazFIVWxGaWVrWnRWbFJSSWl3aWFIUnRJam9pVUU5VFZDSXNJbWgwZFNJNkltaDBkSEE2THk5M2FYSmxMbU52YlRveE9UZ3dNeTlqYkdsbGJuUnpMemRtTXprNU1EQTRNekEzTkRBd01EZ3ZZV05qWlhOekxYUnZhMlZ1SWl3aVkyaGhiQ0k2SWtvMk5YVkpRWE5WYW1SS2RrNUdNRVp5Wmpkc2VWQnNUemRvYkVSSGJsZG9JaXdpYUdGdVpHeGxJam9pZDJseVpXRndjRG92THlVME1HRnNhV05sWDNkcGNtVkFkMmx5WlM1amIyMGlMQ0owWldGdElqb2lkMmx5WlNKOS40RURId3M5X3JlUmtSVEJaYmpTYWkwUlB3Z1RRX2RUbzFfWkxjZXlYbkZUWHVDeG4yM1g4bkFMZWhlMndwclA3ZUZlWFFJa3NGZ01BSTJCcWw5aXJCZyIsImNsaWVudF9pZCI6IndpcmVhcHA6Ly9xSGlETHNia1QyLXA5dVNKc21yWl9BITdmMzk5MDA4MzA3NDAwMDhAd2lyZS5jb20iLCJhcGlfdmVyc2lvbiI6NSwic2NvcGUiOiJ3aXJlX2NsaWVudF9pZCJ9._1iBdjC9MUNMi8nk1IvZTHpOgdcdejz-vg5RTFRW3Mg0BnvYicGSUlxMyFtEe_fQg5iIObSlwB0GrIqeCN3OAw",
   "type": "DPoP"
 }
 ```
@@ -351,43 +350,43 @@ dpop: ZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNkltUndiM0FyYW5kMElpd2lhbmRySWpwN0ltdD
 <details>
 <summary><b>Access token</b></summary>
 
-See it on [jwt.io](https://jwt.io/#id_token=eyJhbGciOiJFZERTQSIsInR5cCI6ImF0K2p3dCIsImp3ayI6eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6IjlydDJMVHVyeTRJQTFZZExVYU4zT1JYUzRtZVlZTmhybWMtcXVYWUcxQjAifX0.eyJpYXQiOjE3MDUzMzI0NDksImV4cCI6MTcwNTMzNjQwOSwibmJmIjoxNzA1MzMyNDQ5LCJpc3MiOiJodHRwOi8vd2lyZS5jb206MjI1MDQvY2xpZW50cy9jN2RkYmFiMWE1MjI1ZGUxL2FjY2Vzcy10b2tlbiIsInN1YiI6IndpcmVhcHA6Ly9JUjBfSU10Q1RMaTNhczVFb0NCd1hnIWM3ZGRiYWIxYTUyMjVkZTFAd2lyZS5jb20iLCJhdWQiOiJodHRwOi8vd2lyZS5jb206MjI1MDQvY2xpZW50cy9jN2RkYmFiMWE1MjI1ZGUxL2FjY2Vzcy10b2tlbiIsImp0aSI6ImI0N2MwYmFlLWM1OGMtNGI3ZC05YTA0LTVhNWFkMWVlMDhjYiIsIm5vbmNlIjoiYjB0Vk9HdzVka3B4Y0RGYWJXTm5XRUpCY2s1a2VVTjJSM1J6UlV0TGRqayIsImNoYWwiOiIyNXhDalpsMHdndjFqQ1U0SXU2SGR0b3NCNnlZdnVTYyIsImNuZiI6eyJraWQiOiJTU3htTVBJanhaWC1lRHhBa1JreDhjWEpoRE1XUlRHTGhGNXV5VmVqUDRvIn0sInByb29mIjoiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNkltUndiM0FyYW5kMElpd2lhbmRySWpwN0ltdDBlU0k2SWs5TFVDSXNJbU55ZGlJNklrVmtNalUxTVRraUxDSjRJam9pTTFkbk5rUnFZbTlhZWtWa1JsUjBkRzlVYVZRdFlsTjFRemszTlZCeGFuRlNXRmxyWm5CVGExaHNRU0o5ZlEuZXlKcFlYUWlPakUzTURVek16STBORGtzSW1WNGNDSTZNVGN3TlRNek9UWTBPU3dpYm1KbUlqb3hOekExTXpNeU5EUTVMQ0p6ZFdJaU9pSjNhWEpsWVhCd09pOHZTVkl3WDBsTmRFTlVUR2t6WVhNMVJXOURRbmRZWnlGak4yUmtZbUZpTVdFMU1qSTFaR1V4UUhkcGNtVXVZMjl0SWl3aWFuUnBJam9pWXpoaE9EVTRZMll0T0RRelppMDBOR1JqTFdGbVptWXROelZrTURFeVptTXpaak5sSWl3aWJtOXVZMlVpT2lKaU1IUldUMGQzTldScmNIaGpSRVpoWWxkT2JsZEZTa0pqYXpWclpWVk9NbEl6VW5wU1ZYUk1aR3BySWl3aWFIUnRJam9pVUU5VFZDSXNJbWgwZFNJNkltaDBkSEE2THk5M2FYSmxMbU52YlRveU1qVXdOQzlqYkdsbGJuUnpMMk0zWkdSaVlXSXhZVFV5TWpWa1pURXZZV05qWlhOekxYUnZhMlZ1SWl3aVkyaGhiQ0k2SWpJMWVFTnFXbXd3ZDJkMk1XcERWVFJKZFRaSVpIUnZjMEkyZVZsMmRWTmpJaXdpYUdGdVpHeGxJam9pZDJseVpXRndjRG92THlVME1HRnNhV05sWDNkcGNtVkFkMmx5WlM1amIyMGlMQ0owWldGdElqb2lkMmx5WlNKOS5NeFZBdkRDS0VHaXJzVnN1QlN5OENSMlFKU2Nza0dsaVo3TDdFanFPellKbHQ4Ni1TWFE4Zy1KSktGa0hXa29zX3RtVW80S2VONUFXZXJtd3cyd1lEZyIsImNsaWVudF9pZCI6IndpcmVhcHA6Ly9JUjBfSU10Q1RMaTNhczVFb0NCd1hnIWM3ZGRiYWIxYTUyMjVkZTFAd2lyZS5jb20iLCJhcGlfdmVyc2lvbiI6NSwic2NvcGUiOiJ3aXJlX2NsaWVudF9pZCJ9.gn9AhrsnwaVKLnSCg3SAlClc37Ywj85Uz8P3uMlO_mpw6HUAKEkPBMMunSfnhwd3tCiynne5_u4HBcVD3HwiAA)
+See it on [jwt.io](https://jwt.io/#id_token=eyJhbGciOiJFZERTQSIsInR5cCI6ImF0K2p3dCIsImp3ayI6eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Imhnbzl1SGEwNTg4bWsxM3F0bzZBMzl6Yk0xOW92OVk4SjRPSnVTLVZWQncifX0.eyJpYXQiOjE3MDU0MTQxNjAsImV4cCI6MTcwNTQxODEyMCwibmJmIjoxNzA1NDE0MTYwLCJpc3MiOiJodHRwOi8vd2lyZS5jb206MTk4MDMvY2xpZW50cy83ZjM5OTAwODMwNzQwMDA4L2FjY2Vzcy10b2tlbiIsInN1YiI6IndpcmVhcHA6Ly9xSGlETHNia1QyLXA5dVNKc21yWl9BITdmMzk5MDA4MzA3NDAwMDhAd2lyZS5jb20iLCJhdWQiOiJodHRwOi8vd2lyZS5jb206MTk4MDMvY2xpZW50cy83ZjM5OTAwODMwNzQwMDA4L2FjY2Vzcy10b2tlbiIsImp0aSI6IjA4NWZiNWJjLTQ5OWUtNDFlMi1iZTJjLWY2ZTQxOWUxODgzMSIsIm5vbmNlIjoiU25weldVWmFWWFp4YTBwR1lrSlJVekJLT0d3NVEweEZNR1JRYnpGbVZUUSIsImNoYWwiOiJKNjV1SUFzVWpkSnZORjBGcmY3bHlQbE83aGxER25XaCIsImNuZiI6eyJraWQiOiI2QXl3V21OVER5Q3hXRzdZSkF6M2tSeGVjZUEtdDJYbm1UMHR3QUpKYmowIn0sInByb29mIjoiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNkltUndiM0FyYW5kMElpd2lhbmRySWpwN0ltdDBlU0k2SWs5TFVDSXNJbU55ZGlJNklrVmtNalUxTVRraUxDSjRJam9pTkhVNFZFOVFiMUphTFVaMVJVaG5SRmg0TTJGUGJWcGFZVlpwUjFKZlgzUkRPVTlCZVVsTWNqVnhZeUo5ZlEuZXlKcFlYUWlPakUzTURVME1UUXhOakFzSW1WNGNDSTZNVGN3TlRReU1UTTJNQ3dpYm1KbUlqb3hOekExTkRFME1UWXdMQ0p6ZFdJaU9pSjNhWEpsWVhCd09pOHZjVWhwUkV4elltdFVNaTF3T1hWVFNuTnRjbHBmUVNFM1pqTTVPVEF3T0RNd056UXdNREE0UUhkcGNtVXVZMjl0SWl3aWFuUnBJam9pWlRnMk1UUmhPR0l0TURBeE5pMDBaakZrTFRnMVpHWXRaakppTjJVMU9HWmhOVGsySWl3aWJtOXVZMlVpT2lKVGJuQjZWMVZhWVZaWVduaGhNSEJIV1d0S1VsVjZRa3RQUjNjMVVUQjRSazFIVWxGaWVrWnRWbFJSSWl3aWFIUnRJam9pVUU5VFZDSXNJbWgwZFNJNkltaDBkSEE2THk5M2FYSmxMbU52YlRveE9UZ3dNeTlqYkdsbGJuUnpMemRtTXprNU1EQTRNekEzTkRBd01EZ3ZZV05qWlhOekxYUnZhMlZ1SWl3aVkyaGhiQ0k2SWtvMk5YVkpRWE5WYW1SS2RrNUdNRVp5Wmpkc2VWQnNUemRvYkVSSGJsZG9JaXdpYUdGdVpHeGxJam9pZDJseVpXRndjRG92THlVME1HRnNhV05sWDNkcGNtVkFkMmx5WlM1amIyMGlMQ0owWldGdElqb2lkMmx5WlNKOS40RURId3M5X3JlUmtSVEJaYmpTYWkwUlB3Z1RRX2RUbzFfWkxjZXlYbkZUWHVDeG4yM1g4bkFMZWhlMndwclA3ZUZlWFFJa3NGZ01BSTJCcWw5aXJCZyIsImNsaWVudF9pZCI6IndpcmVhcHA6Ly9xSGlETHNia1QyLXA5dVNKc21yWl9BITdmMzk5MDA4MzA3NDAwMDhAd2lyZS5jb20iLCJhcGlfdmVyc2lvbiI6NSwic2NvcGUiOiJ3aXJlX2NsaWVudF9pZCJ9._1iBdjC9MUNMi8nk1IvZTHpOgdcdejz-vg5RTFRW3Mg0BnvYicGSUlxMyFtEe_fQg5iIObSlwB0GrIqeCN3OAw)
 
 Raw:
 ```text
 eyJhbGciOiJFZERTQSIsInR5cCI6ImF0K2p3dCIsImp3ayI6eyJrdHkiOiJPS1Ai
-LCJjcnYiOiJFZDI1NTE5IiwieCI6IjlydDJMVHVyeTRJQTFZZExVYU4zT1JYUzRt
-ZVlZTmhybWMtcXVYWUcxQjAifX0.eyJpYXQiOjE3MDUzMzI0NDksImV4cCI6MTcw
-NTMzNjQwOSwibmJmIjoxNzA1MzMyNDQ5LCJpc3MiOiJodHRwOi8vd2lyZS5jb206
-MjI1MDQvY2xpZW50cy9jN2RkYmFiMWE1MjI1ZGUxL2FjY2Vzcy10b2tlbiIsInN1
-YiI6IndpcmVhcHA6Ly9JUjBfSU10Q1RMaTNhczVFb0NCd1hnIWM3ZGRiYWIxYTUy
-MjVkZTFAd2lyZS5jb20iLCJhdWQiOiJodHRwOi8vd2lyZS5jb206MjI1MDQvY2xp
-ZW50cy9jN2RkYmFiMWE1MjI1ZGUxL2FjY2Vzcy10b2tlbiIsImp0aSI6ImI0N2Mw
-YmFlLWM1OGMtNGI3ZC05YTA0LTVhNWFkMWVlMDhjYiIsIm5vbmNlIjoiYjB0Vk9H
-dzVka3B4Y0RGYWJXTm5XRUpCY2s1a2VVTjJSM1J6UlV0TGRqayIsImNoYWwiOiIy
-NXhDalpsMHdndjFqQ1U0SXU2SGR0b3NCNnlZdnVTYyIsImNuZiI6eyJraWQiOiJT
-U3htTVBJanhaWC1lRHhBa1JreDhjWEpoRE1XUlRHTGhGNXV5VmVqUDRvIn0sInBy
+LCJjcnYiOiJFZDI1NTE5IiwieCI6Imhnbzl1SGEwNTg4bWsxM3F0bzZBMzl6Yk0x
+OW92OVk4SjRPSnVTLVZWQncifX0.eyJpYXQiOjE3MDU0MTQxNjAsImV4cCI6MTcw
+NTQxODEyMCwibmJmIjoxNzA1NDE0MTYwLCJpc3MiOiJodHRwOi8vd2lyZS5jb206
+MTk4MDMvY2xpZW50cy83ZjM5OTAwODMwNzQwMDA4L2FjY2Vzcy10b2tlbiIsInN1
+YiI6IndpcmVhcHA6Ly9xSGlETHNia1QyLXA5dVNKc21yWl9BITdmMzk5MDA4MzA3
+NDAwMDhAd2lyZS5jb20iLCJhdWQiOiJodHRwOi8vd2lyZS5jb206MTk4MDMvY2xp
+ZW50cy83ZjM5OTAwODMwNzQwMDA4L2FjY2Vzcy10b2tlbiIsImp0aSI6IjA4NWZi
+NWJjLTQ5OWUtNDFlMi1iZTJjLWY2ZTQxOWUxODgzMSIsIm5vbmNlIjoiU25weldV
+WmFWWFp4YTBwR1lrSlJVekJLT0d3NVEweEZNR1JRYnpGbVZUUSIsImNoYWwiOiJK
+NjV1SUFzVWpkSnZORjBGcmY3bHlQbE83aGxER25XaCIsImNuZiI6eyJraWQiOiI2
+QXl3V21OVER5Q3hXRzdZSkF6M2tSeGVjZUEtdDJYbm1UMHR3QUpKYmowIn0sInBy
 b29mIjoiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNkltUndiM0FyYW5kMElp
 d2lhbmRySWpwN0ltdDBlU0k2SWs5TFVDSXNJbU55ZGlJNklrVmtNalUxTVRraUxD
-SjRJam9pTTFkbk5rUnFZbTlhZWtWa1JsUjBkRzlVYVZRdFlsTjFRemszTlZCeGFu
-RlNXRmxyWm5CVGExaHNRU0o5ZlEuZXlKcFlYUWlPakUzTURVek16STBORGtzSW1W
-NGNDSTZNVGN3TlRNek9UWTBPU3dpYm1KbUlqb3hOekExTXpNeU5EUTVMQ0p6ZFdJ
-aU9pSjNhWEpsWVhCd09pOHZTVkl3WDBsTmRFTlVUR2t6WVhNMVJXOURRbmRZWnlG
-ak4yUmtZbUZpTVdFMU1qSTFaR1V4UUhkcGNtVXVZMjl0SWl3aWFuUnBJam9pWXpo
-aE9EVTRZMll0T0RRelppMDBOR1JqTFdGbVptWXROelZrTURFeVptTXpaak5sSWl3
-aWJtOXVZMlVpT2lKaU1IUldUMGQzTldScmNIaGpSRVpoWWxkT2JsZEZTa0pqYXpW
-clpWVk9NbEl6VW5wU1ZYUk1aR3BySWl3aWFIUnRJam9pVUU5VFZDSXNJbWgwZFNJ
-NkltaDBkSEE2THk5M2FYSmxMbU52YlRveU1qVXdOQzlqYkdsbGJuUnpMMk0zWkdS
-aVlXSXhZVFV5TWpWa1pURXZZV05qWlhOekxYUnZhMlZ1SWl3aVkyaGhiQ0k2SWpJ
-MWVFTnFXbXd3ZDJkMk1XcERWVFJKZFRaSVpIUnZjMEkyZVZsMmRWTmpJaXdpYUdG
+SjRJam9pTkhVNFZFOVFiMUphTFVaMVJVaG5SRmg0TTJGUGJWcGFZVlpwUjFKZlgz
+UkRPVTlCZVVsTWNqVnhZeUo5ZlEuZXlKcFlYUWlPakUzTURVME1UUXhOakFzSW1W
+NGNDSTZNVGN3TlRReU1UTTJNQ3dpYm1KbUlqb3hOekExTkRFME1UWXdMQ0p6ZFdJ
+aU9pSjNhWEpsWVhCd09pOHZjVWhwUkV4elltdFVNaTF3T1hWVFNuTnRjbHBmUVNF
+M1pqTTVPVEF3T0RNd056UXdNREE0UUhkcGNtVXVZMjl0SWl3aWFuUnBJam9pWlRn
+Mk1UUmhPR0l0TURBeE5pMDBaakZrTFRnMVpHWXRaakppTjJVMU9HWmhOVGsySWl3
+aWJtOXVZMlVpT2lKVGJuQjZWMVZhWVZaWVduaGhNSEJIV1d0S1VsVjZRa3RQUjNj
+MVVUQjRSazFIVWxGaWVrWnRWbFJSSWl3aWFIUnRJam9pVUU5VFZDSXNJbWgwZFNJ
+NkltaDBkSEE2THk5M2FYSmxMbU52YlRveE9UZ3dNeTlqYkdsbGJuUnpMemRtTXpr
+NU1EQTRNekEzTkRBd01EZ3ZZV05qWlhOekxYUnZhMlZ1SWl3aVkyaGhiQ0k2SWtv
+Mk5YVkpRWE5WYW1SS2RrNUdNRVp5Wmpkc2VWQnNUemRvYkVSSGJsZG9JaXdpYUdG
 dVpHeGxJam9pZDJseVpXRndjRG92THlVME1HRnNhV05sWDNkcGNtVkFkMmx5WlM1
-amIyMGlMQ0owWldGdElqb2lkMmx5WlNKOS5NeFZBdkRDS0VHaXJzVnN1QlN5OENS
-MlFKU2Nza0dsaVo3TDdFanFPellKbHQ4Ni1TWFE4Zy1KSktGa0hXa29zX3RtVW80
-S2VONUFXZXJtd3cyd1lEZyIsImNsaWVudF9pZCI6IndpcmVhcHA6Ly9JUjBfSU10
-Q1RMaTNhczVFb0NCd1hnIWM3ZGRiYWIxYTUyMjVkZTFAd2lyZS5jb20iLCJhcGlf
-dmVyc2lvbiI6NSwic2NvcGUiOiJ3aXJlX2NsaWVudF9pZCJ9.gn9AhrsnwaVKLnS
-Cg3SAlClc37Ywj85Uz8P3uMlO_mpw6HUAKEkPBMMunSfnhwd3tCiynne5_u4HBcV
-D3HwiAA
+amIyMGlMQ0owWldGdElqb2lkMmx5WlNKOS40RURId3M5X3JlUmtSVEJaYmpTYWkw
+UlB3Z1RRX2RUbzFfWkxjZXlYbkZUWHVDeG4yM1g4bkFMZWhlMndwclA3ZUZlWFFJ
+a3NGZ01BSTJCcWw5aXJCZyIsImNsaWVudF9pZCI6IndpcmVhcHA6Ly9xSGlETHNi
+a1QyLXA5dVNKc21yWl9BITdmMzk5MDA4MzA3NDAwMDhAd2lyZS5jb20iLCJhcGlf
+dmVyc2lvbiI6NSwic2NvcGUiOiJ3aXJlX2NsaWVudF9pZCJ9._1iBdjC9MUNMi8n
+k1IvZTHpOgdcdejz-vg5RTFRW3Mg0BnvYicGSUlxMyFtEe_fQg5iIObSlwB0GrIq
+eCN3OAw
 ```
 
 Decoded:
@@ -398,7 +397,7 @@ Decoded:
   "jwk": {
     "crv": "Ed25519",
     "kty": "OKP",
-    "x": "9rt2LTury4IA1YdLUaN3ORXS4meYYNhrmc-quXYG1B0"
+    "x": "hgo9uHa0588mk13qto6A39zbM19ov9Y8J4OJuS-VVBw"
   },
   "typ": "at+jwt"
 }
@@ -407,21 +406,21 @@ Decoded:
 ```json
 {
   "api_version": 5,
-  "aud": "http://wire.com:22504/clients/c7ddbab1a5225de1/access-token",
-  "chal": "25xCjZl0wgv1jCU4Iu6HdtosB6yYvuSc",
-  "client_id": "wireapp://IR0_IMtCTLi3as5EoCBwXg!c7ddbab1a5225de1@wire.com",
+  "aud": "http://wire.com:19803/clients/7f39900830740008/access-token",
+  "chal": "J65uIAsUjdJvNF0Frf7lyPlO7hlDGnWh",
+  "client_id": "wireapp://qHiDLsbkT2-p9uSJsmrZ_A!7f39900830740008@wire.com",
   "cnf": {
-    "kid": "SSxmMPIjxZX-eDxAkRkx8cXJhDMWRTGLhF5uyVejP4o"
+    "kid": "6AywWmNTDyCxWG7YJAz3kRxeceA-t2XnmT0twAJJbj0"
   },
-  "exp": 1705336409,
-  "iat": 1705332449,
-  "iss": "http://wire.com:22504/clients/c7ddbab1a5225de1/access-token",
-  "jti": "b47c0bae-c58c-4b7d-9a04-5a5ad1ee08cb",
-  "nbf": 1705332449,
-  "nonce": "b0tVOGw5dkpxcDFabWNnWEJBck5keUN2R3RzRUtLdjk",
-  "proof": "eyJhbGciOiJFZERTQSIsInR5cCI6ImRwb3Arand0IiwiandrIjp7Imt0eSI6Ik9LUCIsImNydiI6IkVkMjU1MTkiLCJ4IjoiM1dnNkRqYm9aekVkRlR0dG9UaVQtYlN1Qzk3NVBxanFSWFlrZnBTa1hsQSJ9fQ.eyJpYXQiOjE3MDUzMzI0NDksImV4cCI6MTcwNTMzOTY0OSwibmJmIjoxNzA1MzMyNDQ5LCJzdWIiOiJ3aXJlYXBwOi8vSVIwX0lNdENUTGkzYXM1RW9DQndYZyFjN2RkYmFiMWE1MjI1ZGUxQHdpcmUuY29tIiwianRpIjoiYzhhODU4Y2YtODQzZi00NGRjLWFmZmYtNzVkMDEyZmMzZjNlIiwibm9uY2UiOiJiMHRWT0d3NWRrcHhjREZhYldObldFSkJjazVrZVVOMlIzUnpSVXRMZGprIiwiaHRtIjoiUE9TVCIsImh0dSI6Imh0dHA6Ly93aXJlLmNvbToyMjUwNC9jbGllbnRzL2M3ZGRiYWIxYTUyMjVkZTEvYWNjZXNzLXRva2VuIiwiY2hhbCI6IjI1eENqWmwwd2d2MWpDVTRJdTZIZHRvc0I2eVl2dVNjIiwiaGFuZGxlIjoid2lyZWFwcDovLyU0MGFsaWNlX3dpcmVAd2lyZS5jb20iLCJ0ZWFtIjoid2lyZSJ9.MxVAvDCKEGirsVsuBSy8CR2QJScskGliZ7L7EjqOzYJlt86-SXQ8g-JJKFkHWkos_tmUo4KeN5AWermww2wYDg",
+  "exp": 1705418120,
+  "iat": 1705414160,
+  "iss": "http://wire.com:19803/clients/7f39900830740008/access-token",
+  "jti": "085fb5bc-499e-41e2-be2c-f6e419e18831",
+  "nbf": 1705414160,
+  "nonce": "SnpzWUZaVXZxa0pGYkJRUzBKOGw5Q0xFMGRQbzFmVTQ",
+  "proof": "eyJhbGciOiJFZERTQSIsInR5cCI6ImRwb3Arand0IiwiandrIjp7Imt0eSI6Ik9LUCIsImNydiI6IkVkMjU1MTkiLCJ4IjoiNHU4VE9Qb1JaLUZ1RUhnRFh4M2FPbVpaYVZpR1JfX3RDOU9BeUlMcjVxYyJ9fQ.eyJpYXQiOjE3MDU0MTQxNjAsImV4cCI6MTcwNTQyMTM2MCwibmJmIjoxNzA1NDE0MTYwLCJzdWIiOiJ3aXJlYXBwOi8vcUhpRExzYmtUMi1wOXVTSnNtclpfQSE3ZjM5OTAwODMwNzQwMDA4QHdpcmUuY29tIiwianRpIjoiZTg2MTRhOGItMDAxNi00ZjFkLTg1ZGYtZjJiN2U1OGZhNTk2Iiwibm9uY2UiOiJTbnB6V1VaYVZYWnhhMHBHWWtKUlV6QktPR3c1UTB4Rk1HUlFiekZtVlRRIiwiaHRtIjoiUE9TVCIsImh0dSI6Imh0dHA6Ly93aXJlLmNvbToxOTgwMy9jbGllbnRzLzdmMzk5MDA4MzA3NDAwMDgvYWNjZXNzLXRva2VuIiwiY2hhbCI6Iko2NXVJQXNVamRKdk5GMEZyZjdseVBsTzdobERHbldoIiwiaGFuZGxlIjoid2lyZWFwcDovLyU0MGFsaWNlX3dpcmVAd2lyZS5jb20iLCJ0ZWFtIjoid2lyZSJ9.4EDHws9_reRkRTBZbjSai0RPwgTQ_dTo1_ZLceyXnFTXuCxn23X8nALehe2wprP7eFeXQIksFgMAI2Bql9irBg",
   "scope": "wire_client_id",
-  "sub": "wireapp://IR0_IMtCTLi3as5EoCBwXg!c7ddbab1a5225de1@wire.com"
+  "sub": "wireapp://qHiDLsbkT2-p9uSJsmrZ_A!7f39900830740008@wire.com"
 }
 ```
 
@@ -429,10 +428,10 @@ Decoded:
 ✅ Signature Verified with key:
 ```text
 -----BEGIN PRIVATE KEY-----
-MC4CAQAwBQYDK2VwBCIEIKN5EgaKqpnMIHcS7QWSZ/S0sF/e1lAX7d+caj2SLVg/
+MC4CAQAwBQYDK2VwBCIEILTyPwPDjW15I0cFy/drf4/ZnCZw336E0/38wRmUHz4H
 -----END PRIVATE KEY-----
 -----BEGIN PUBLIC KEY-----
-MCowBQYDK2VwAyEA9rt2LTury4IA1YdLUaN3ORXS4meYYNhrmc+quXYG1B0=
+MCowBQYDK2VwAyEAhgo9uHa0588mk13qto6A39zbM19ov9Y8J4OJuS+VVBw=
 -----END PUBLIC KEY-----
 ```
 
@@ -442,28 +441,28 @@ MCowBQYDK2VwAyEA9rt2LTury4IA1YdLUaN3ORXS4meYYNhrmc+quXYG1B0=
 ### Client provides access token
 #### 16. validate Dpop challenge (clientId)
 ```http request
-POST https://stepca:32795/acme/wire/challenge/RO1lN0FiYIud1rZZ6E3uiY5eRdnjVE0o/0cSO2qsiV3grbpg9VN56vlr32RB4rLf4
+POST https://stepca:32900/acme/wire/challenge/PQMMQsFRGJ63rw5BJXcZRW5gdxiAnfza/xnRWBh033703AyPfEirQDytZggaHT2wt
                          /acme/{acme-provisioner}/challenge/{authz-id}/{challenge-id}
 content-type: application/jose+json
 ```
 ```json
 {
-  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMyNzk1L2FjbWUvd2lyZS9hY2NvdW50L1o5cGNJNmlNVHpBMVRFTHUxSU5zbEZ4NkV0aFJlb1ZFIiwidHlwIjoiSldUIiwibm9uY2UiOiJiM05JUjNKMWJrdDNhVXBCZDNnNWVIVm9aMDAzU1c5RVpqbFVObXAyZWtFIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI3OTUvYWNtZS93aXJlL2NoYWxsZW5nZS9STzFsTjBGaVlJdWQxclpaNkUzdWlZNWVSZG5qVkUwby8wY1NPMnFzaVYzZ3JicGc5Vk41NnZscjMyUkI0ckxmNCJ9",
-  "payload": "eyJhY2Nlc3NfdG9rZW4iOiJleUpoYkdjaU9pSkZaRVJUUVNJc0luUjVjQ0k2SW1GMEsycDNkQ0lzSW1wM2F5STZleUpyZEhraU9pSlBTMUFpTENKamNuWWlPaUpGWkRJMU5URTVJaXdpZUNJNklqbHlkREpNVkhWeWVUUkpRVEZaWkV4VllVNHpUMUpZVXpSdFpWbFpUbWh5YldNdGNYVllXVWN4UWpBaWZYMC5leUpwWVhRaU9qRTNNRFV6TXpJME5Ea3NJbVY0Y0NJNk1UY3dOVE16TmpRd09Td2libUptSWpveE56QTFNek15TkRRNUxDSnBjM01pT2lKb2RIUndPaTh2ZDJseVpTNWpiMjA2TWpJMU1EUXZZMnhwWlc1MGN5OWpOMlJrWW1GaU1XRTFNakkxWkdVeEwyRmpZMlZ6Y3kxMGIydGxiaUlzSW5OMVlpSTZJbmRwY21WaGNIQTZMeTlKVWpCZlNVMTBRMVJNYVROaGN6VkZiME5DZDFobklXTTNaR1JpWVdJeFlUVXlNalZrWlRGQWQybHlaUzVqYjIwaUxDSmhkV1FpT2lKb2RIUndPaTh2ZDJseVpTNWpiMjA2TWpJMU1EUXZZMnhwWlc1MGN5OWpOMlJrWW1GaU1XRTFNakkxWkdVeEwyRmpZMlZ6Y3kxMGIydGxiaUlzSW1wMGFTSTZJbUkwTjJNd1ltRmxMV00xT0dNdE5HSTNaQzA1WVRBMExUVmhOV0ZrTVdWbE1EaGpZaUlzSW01dmJtTmxJam9pWWpCMFZrOUhkelZrYTNCNFkwUkdZV0pYVG01WFJVcENZMnMxYTJWVlRqSlNNMUo2VWxWMFRHUnFheUlzSW1Ob1lXd2lPaUl5TlhoRGFscHNNSGRuZGpGcVExVTBTWFUyU0dSMGIzTkNObmxaZG5WVFl5SXNJbU51WmlJNmV5SnJhV1FpT2lKVFUzaHRUVkJKYW5oYVdDMWxSSGhCYTFKcmVEaGpXRXBvUkUxWFVsUkhUR2hHTlhWNVZtVnFVRFJ2SW4wc0luQnliMjltSWpvaVpYbEthR0pIWTJsUGFVcEdXa1ZTVkZGVFNYTkpibEkxWTBOSk5rbHRVbmRpTTBGeVlXNWtNRWxwZDJsaGJtUnlTV3B3TjBsdGREQmxVMGsyU1dzNVRGVkRTWE5KYlU1NVpHbEpOa2xyVm10TmFsVXhUVlJyYVV4RFNqUkphbTlwVFRGa2JrNXJVbkZaYlRsaFpXdFdhMUpzVWpCa1J6bFZZVlpSZEZsc1RqRlJlbXN6VGxaQ2VHRnVSbE5YUm14eVdtNUNWR0V4YUhOUlUwbzVabEV1WlhsS2NGbFlVV2xQYWtVelRVUlZlazE2U1RCT1JHdHpTVzFXTkdORFNUWk5WR04zVGxSTmVrOVVXVEJQVTNkcFltMUtiVWxxYjNoT2VrRXhUWHBOZVU1RVVUVk1RMHA2WkZkSmFVOXBTak5oV0Vwc1dWaENkMDlwT0haVFZrbDNXREJzVG1SRlRsVlVSMnQ2V1ZoTk1WSlhPVVJSYm1SWldubEdhazR5VW10WmJVWnBUVmRGTVUxcVNURmFSMVY0VVVoa2NHTnRWWFZaTWpsMFNXbDNhV0Z1VW5CSmFtOXBXWHBvYUU5RVZUUlpNbGwwVDBSUmVscHBNREJPUjFKcVRGZEdiVnB0V1hST2VsWnJUVVJGZVZwdFRYcGFhazVzU1dsM2FXSnRPWFZaTWxWcFQybEthVTFJVWxkVU1HUXpUbGRTY21OSWFHcFNSVnBvV1d4a1QySnNaRVpUYTBwcVlYcFdjbHBXVms5TmJFbDZWVzV3VTFaWVVrMWFSM0J5U1dsM2FXRklVblJKYW05cFZVVTVWRlpEU1hOSmJXZ3daRk5KTmtsdGFEQmtTRUUyVEhrNU0yRllTbXhNYlU1MllsUnZlVTFxVlhkT1F6bHFZa2RzYkdKdVVucE1NazB6V2tkU2FWbFhTWGhaVkZWNVRXcFdhMXBVUlhaWlYwNXFXbGhPZWt4WVVuWmhNbFoxU1dsM2FWa3lhR2hpUTBrMlNXcEpNV1ZGVG5GWGJYZDNaREprTWsxWGNFUldWRkpLWkZSYVNWcElVblpqTUVreVpWWnNNbVJXVG1wSmFYZHBZVWRHZFZwSGVHeEphbTlwWkRKc2VWcFhSbmRqUkc5MlRIbFZNRTFIUm5OaFYwNXNXRE5rY0dOdFZrRmtNbXg1V2xNMWFtSXlNR2xNUTBvd1dsZEdkRWxxYjJsa01teDVXbE5LT1M1TmVGWkJka1JEUzBWSGFYSnpWbk4xUWxONU9FTlNNbEZLVTJOemEwZHNhVm8zVERkRmFuRlBlbGxLYkhRNE5pMVRXRkU0WnkxS1NrdEdhMGhYYTI5elgzUnRWVzgwUzJWT05VRlhaWEp0ZDNjeWQxbEVaeUlzSW1Oc2FXVnVkRjlwWkNJNkluZHBjbVZoY0hBNkx5OUpVakJmU1UxMFExUk1hVE5oY3pWRmIwTkNkMWhuSVdNM1pHUmlZV0l4WVRVeU1qVmtaVEZBZDJseVpTNWpiMjBpTENKaGNHbGZkbVZ5YzJsdmJpSTZOU3dpYzJOdmNHVWlPaUozYVhKbFgyTnNhV1Z1ZEY5cFpDSjkuZ245QWhyc253YVZLTG5TQ2czU0FsQ2xjMzdZd2o4NVV6OFAzdU1sT19tcHc2SFVBS0VrUEJNTXVuU2ZuaHdkM3RDaXlubmU1X3U0SEJjVkQzSHdpQUEifQ",
-  "signature": "w6gp-laBSv5hi-LC8lfMWlp8aJGgllMZDS_6K3WOdlknA7OWCPT98uEP8d2-rtyoYSMcR7_MWV9ZCHiUN0zYBQ"
+  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMyOTAwL2FjbWUvd2lyZS9hY2NvdW50L2dOTlI1Y0x0N1Q4MWR0QzJ6emVoRXZRS3U0TEFZQnl6IiwidHlwIjoiSldUIiwibm9uY2UiOiJaemhrVm1Sd09EVlJkbWhGYWtaSlJsQlJkVUZUTkdod09FUjZlWEZDZEU0IiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI5MDAvYWNtZS93aXJlL2NoYWxsZW5nZS9QUU1NUXNGUkdKNjNydzVCSlhjWlJXNWdkeGlBbmZ6YS94blJXQmgwMzM3MDNBeVBmRWlyUUR5dFpnZ2FIVDJ3dCJ9",
+  "payload": "eyJhY2Nlc3NfdG9rZW4iOiJleUpoYkdjaU9pSkZaRVJUUVNJc0luUjVjQ0k2SW1GMEsycDNkQ0lzSW1wM2F5STZleUpyZEhraU9pSlBTMUFpTENKamNuWWlPaUpGWkRJMU5URTVJaXdpZUNJNkltaG5iemwxU0dFd05UZzRiV3N4TTNGMGJ6WkJNemw2WWsweE9XOTJPVms0U2pSUFNuVlRMVlpXUW5jaWZYMC5leUpwWVhRaU9qRTNNRFUwTVRReE5qQXNJbVY0Y0NJNk1UY3dOVFF4T0RFeU1Dd2libUptSWpveE56QTFOREUwTVRZd0xDSnBjM01pT2lKb2RIUndPaTh2ZDJseVpTNWpiMjA2TVRrNE1ETXZZMnhwWlc1MGN5ODNaak01T1RBd09ETXdOelF3TURBNEwyRmpZMlZ6Y3kxMGIydGxiaUlzSW5OMVlpSTZJbmRwY21WaGNIQTZMeTl4U0dsRVRITmlhMVF5TFhBNWRWTktjMjF5V2w5QklUZG1Nems1TURBNE16QTNOREF3TURoQWQybHlaUzVqYjIwaUxDSmhkV1FpT2lKb2RIUndPaTh2ZDJseVpTNWpiMjA2TVRrNE1ETXZZMnhwWlc1MGN5ODNaak01T1RBd09ETXdOelF3TURBNEwyRmpZMlZ6Y3kxMGIydGxiaUlzSW1wMGFTSTZJakE0TldaaU5XSmpMVFE1T1dVdE5ERmxNaTFpWlRKakxXWTJaVFF4T1dVeE9EZ3pNU0lzSW01dmJtTmxJam9pVTI1d2VsZFZXbUZXV0ZwNFlUQndSMWxyU2xKVmVrSkxUMGQzTlZFd2VFWk5SMUpSWW5wR2JWWlVVU0lzSW1Ob1lXd2lPaUpLTmpWMVNVRnpWV3BrU25aT1JqQkdjbVkzYkhsUWJFODNhR3hFUjI1WGFDSXNJbU51WmlJNmV5SnJhV1FpT2lJMlFYbDNWMjFPVkVSNVEzaFhSemRaU2tGNk0ydFNlR1ZqWlVFdGRESllibTFVTUhSM1FVcEtZbW93SW4wc0luQnliMjltSWpvaVpYbEthR0pIWTJsUGFVcEdXa1ZTVkZGVFNYTkpibEkxWTBOSk5rbHRVbmRpTTBGeVlXNWtNRWxwZDJsaGJtUnlTV3B3TjBsdGREQmxVMGsyU1dzNVRGVkRTWE5KYlU1NVpHbEpOa2xyVm10TmFsVXhUVlJyYVV4RFNqUkphbTlwVGtoVk5GWkZPVkZpTVVwaFRGVmFNVkpWYUc1U1JtZzBUVEpHVUdKV2NHRlpWbHB3VWpGS1psZ3pVa1JQVlRsQ1pWVnNUV05xVm5oWmVVbzVabEV1WlhsS2NGbFlVV2xQYWtVelRVUlZNRTFVVVhoT2FrRnpTVzFXTkdORFNUWk5WR04zVGxSUmVVMVVUVEpOUTNkcFltMUtiVWxxYjNoT2VrRXhUa1JGTUUxVVdYZE1RMHA2WkZkSmFVOXBTak5oV0Vwc1dWaENkMDlwT0haalZXaHdVa1Y0ZWxsdGRGVk5hVEYzVDFoV1ZGTnVUblJqYkhCbVVWTkZNMXBxVFRWUFZFRjNUMFJOZDA1NlVYZE5SRUUwVVVoa2NHTnRWWFZaTWpsMFNXbDNhV0Z1VW5CSmFtOXBXbFJuTWsxVVVtaFBSMGwwVFVSQmVFNXBNREJhYWtaclRGUm5NVnBIV1hSYWFrcHBUakpWTVU5SFdtaE9WR3N5U1dsM2FXSnRPWFZaTWxWcFQybEtWR0p1UWpaV01WWmhXVlphV1ZkdWFHaE5TRUpJVjFkMFMxVnNWalpSYTNSUVVqTmpNVlZVUWpSU2F6RklWV3hHYVdWclduUldiRkpTU1dsM2FXRklVblJKYW05cFZVVTVWRlpEU1hOSmJXZ3daRk5KTmtsdGFEQmtTRUUyVEhrNU0yRllTbXhNYlU1MllsUnZlRTlVWjNkTmVUbHFZa2RzYkdKdVVucE1lbVJ0VFhwck5VMUVRVFJOZWtFelRrUkJkMDFFWjNaWlYwNXFXbGhPZWt4WVVuWmhNbFoxU1dsM2FWa3lhR2hpUTBrMlNXdHZNazVZVmtwUldFNVdZVzFTUzJSck5VZE5SVnA1V21wa2MyVldRbk5VZW1SdllrVlNTR0pzWkc5SmFYZHBZVWRHZFZwSGVHeEphbTlwWkRKc2VWcFhSbmRqUkc5MlRIbFZNRTFIUm5OaFYwNXNXRE5rY0dOdFZrRmtNbXg1V2xNMWFtSXlNR2xNUTBvd1dsZEdkRWxxYjJsa01teDVXbE5LT1M0MFJVUklkM001WDNKbFVtdFNWRUphWW1wVFlXa3dVbEIzWjFSUlgyUlViekZmV2t4alpYbFlia1pVV0hWRGVHNHlNMWc0YmtGTVpXaGxNbmR3Y2xBM1pVWmxXRkZKYTNOR1owMUJTVEpDY1d3NWFYSkNaeUlzSW1Oc2FXVnVkRjlwWkNJNkluZHBjbVZoY0hBNkx5OXhTR2xFVEhOaWExUXlMWEE1ZFZOS2MyMXlXbDlCSVRkbU16azVNREE0TXpBM05EQXdNRGhBZDJseVpTNWpiMjBpTENKaGNHbGZkbVZ5YzJsdmJpSTZOU3dpYzJOdmNHVWlPaUozYVhKbFgyTnNhV1Z1ZEY5cFpDSjkuXzFpQmRqQzlNVU5NaThuazFJdlpUSHBPZ2RjZGVqei12ZzVSVEZSVzNNZzBCbnZZaWNHU1VseE15RnRFZV9mUWc1aUlPYlNsd0IwR3JJcWVDTjNPQXcifQ",
+  "signature": "uTjiZ_TMBZ-2LetgDg8brFLAMsYRaWTPAYptmixO57Ss0M3T1gE9m3K1j4TlNGN_Zatq_RXU_nUJPEUIdkP0BQ"
 }
 ```
 ```json
 {
   "payload": {
-    "access_token": "eyJhbGciOiJFZERTQSIsInR5cCI6ImF0K2p3dCIsImp3ayI6eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6IjlydDJMVHVyeTRJQTFZZExVYU4zT1JYUzRtZVlZTmhybWMtcXVYWUcxQjAifX0.eyJpYXQiOjE3MDUzMzI0NDksImV4cCI6MTcwNTMzNjQwOSwibmJmIjoxNzA1MzMyNDQ5LCJpc3MiOiJodHRwOi8vd2lyZS5jb206MjI1MDQvY2xpZW50cy9jN2RkYmFiMWE1MjI1ZGUxL2FjY2Vzcy10b2tlbiIsInN1YiI6IndpcmVhcHA6Ly9JUjBfSU10Q1RMaTNhczVFb0NCd1hnIWM3ZGRiYWIxYTUyMjVkZTFAd2lyZS5jb20iLCJhdWQiOiJodHRwOi8vd2lyZS5jb206MjI1MDQvY2xpZW50cy9jN2RkYmFiMWE1MjI1ZGUxL2FjY2Vzcy10b2tlbiIsImp0aSI6ImI0N2MwYmFlLWM1OGMtNGI3ZC05YTA0LTVhNWFkMWVlMDhjYiIsIm5vbmNlIjoiYjB0Vk9HdzVka3B4Y0RGYWJXTm5XRUpCY2s1a2VVTjJSM1J6UlV0TGRqayIsImNoYWwiOiIyNXhDalpsMHdndjFqQ1U0SXU2SGR0b3NCNnlZdnVTYyIsImNuZiI6eyJraWQiOiJTU3htTVBJanhaWC1lRHhBa1JreDhjWEpoRE1XUlRHTGhGNXV5VmVqUDRvIn0sInByb29mIjoiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNkltUndiM0FyYW5kMElpd2lhbmRySWpwN0ltdDBlU0k2SWs5TFVDSXNJbU55ZGlJNklrVmtNalUxTVRraUxDSjRJam9pTTFkbk5rUnFZbTlhZWtWa1JsUjBkRzlVYVZRdFlsTjFRemszTlZCeGFuRlNXRmxyWm5CVGExaHNRU0o5ZlEuZXlKcFlYUWlPakUzTURVek16STBORGtzSW1WNGNDSTZNVGN3TlRNek9UWTBPU3dpYm1KbUlqb3hOekExTXpNeU5EUTVMQ0p6ZFdJaU9pSjNhWEpsWVhCd09pOHZTVkl3WDBsTmRFTlVUR2t6WVhNMVJXOURRbmRZWnlGak4yUmtZbUZpTVdFMU1qSTFaR1V4UUhkcGNtVXVZMjl0SWl3aWFuUnBJam9pWXpoaE9EVTRZMll0T0RRelppMDBOR1JqTFdGbVptWXROelZrTURFeVptTXpaak5sSWl3aWJtOXVZMlVpT2lKaU1IUldUMGQzTldScmNIaGpSRVpoWWxkT2JsZEZTa0pqYXpWclpWVk9NbEl6VW5wU1ZYUk1aR3BySWl3aWFIUnRJam9pVUU5VFZDSXNJbWgwZFNJNkltaDBkSEE2THk5M2FYSmxMbU52YlRveU1qVXdOQzlqYkdsbGJuUnpMMk0zWkdSaVlXSXhZVFV5TWpWa1pURXZZV05qWlhOekxYUnZhMlZ1SWl3aVkyaGhiQ0k2SWpJMWVFTnFXbXd3ZDJkMk1XcERWVFJKZFRaSVpIUnZjMEkyZVZsMmRWTmpJaXdpYUdGdVpHeGxJam9pZDJseVpXRndjRG92THlVME1HRnNhV05sWDNkcGNtVkFkMmx5WlM1amIyMGlMQ0owWldGdElqb2lkMmx5WlNKOS5NeFZBdkRDS0VHaXJzVnN1QlN5OENSMlFKU2Nza0dsaVo3TDdFanFPellKbHQ4Ni1TWFE4Zy1KSktGa0hXa29zX3RtVW80S2VONUFXZXJtd3cyd1lEZyIsImNsaWVudF9pZCI6IndpcmVhcHA6Ly9JUjBfSU10Q1RMaTNhczVFb0NCd1hnIWM3ZGRiYWIxYTUyMjVkZTFAd2lyZS5jb20iLCJhcGlfdmVyc2lvbiI6NSwic2NvcGUiOiJ3aXJlX2NsaWVudF9pZCJ9.gn9AhrsnwaVKLnSCg3SAlClc37Ywj85Uz8P3uMlO_mpw6HUAKEkPBMMunSfnhwd3tCiynne5_u4HBcVD3HwiAA"
+    "access_token": "eyJhbGciOiJFZERTQSIsInR5cCI6ImF0K2p3dCIsImp3ayI6eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Imhnbzl1SGEwNTg4bWsxM3F0bzZBMzl6Yk0xOW92OVk4SjRPSnVTLVZWQncifX0.eyJpYXQiOjE3MDU0MTQxNjAsImV4cCI6MTcwNTQxODEyMCwibmJmIjoxNzA1NDE0MTYwLCJpc3MiOiJodHRwOi8vd2lyZS5jb206MTk4MDMvY2xpZW50cy83ZjM5OTAwODMwNzQwMDA4L2FjY2Vzcy10b2tlbiIsInN1YiI6IndpcmVhcHA6Ly9xSGlETHNia1QyLXA5dVNKc21yWl9BITdmMzk5MDA4MzA3NDAwMDhAd2lyZS5jb20iLCJhdWQiOiJodHRwOi8vd2lyZS5jb206MTk4MDMvY2xpZW50cy83ZjM5OTAwODMwNzQwMDA4L2FjY2Vzcy10b2tlbiIsImp0aSI6IjA4NWZiNWJjLTQ5OWUtNDFlMi1iZTJjLWY2ZTQxOWUxODgzMSIsIm5vbmNlIjoiU25weldVWmFWWFp4YTBwR1lrSlJVekJLT0d3NVEweEZNR1JRYnpGbVZUUSIsImNoYWwiOiJKNjV1SUFzVWpkSnZORjBGcmY3bHlQbE83aGxER25XaCIsImNuZiI6eyJraWQiOiI2QXl3V21OVER5Q3hXRzdZSkF6M2tSeGVjZUEtdDJYbm1UMHR3QUpKYmowIn0sInByb29mIjoiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNkltUndiM0FyYW5kMElpd2lhbmRySWpwN0ltdDBlU0k2SWs5TFVDSXNJbU55ZGlJNklrVmtNalUxTVRraUxDSjRJam9pTkhVNFZFOVFiMUphTFVaMVJVaG5SRmg0TTJGUGJWcGFZVlpwUjFKZlgzUkRPVTlCZVVsTWNqVnhZeUo5ZlEuZXlKcFlYUWlPakUzTURVME1UUXhOakFzSW1WNGNDSTZNVGN3TlRReU1UTTJNQ3dpYm1KbUlqb3hOekExTkRFME1UWXdMQ0p6ZFdJaU9pSjNhWEpsWVhCd09pOHZjVWhwUkV4elltdFVNaTF3T1hWVFNuTnRjbHBmUVNFM1pqTTVPVEF3T0RNd056UXdNREE0UUhkcGNtVXVZMjl0SWl3aWFuUnBJam9pWlRnMk1UUmhPR0l0TURBeE5pMDBaakZrTFRnMVpHWXRaakppTjJVMU9HWmhOVGsySWl3aWJtOXVZMlVpT2lKVGJuQjZWMVZhWVZaWVduaGhNSEJIV1d0S1VsVjZRa3RQUjNjMVVUQjRSazFIVWxGaWVrWnRWbFJSSWl3aWFIUnRJam9pVUU5VFZDSXNJbWgwZFNJNkltaDBkSEE2THk5M2FYSmxMbU52YlRveE9UZ3dNeTlqYkdsbGJuUnpMemRtTXprNU1EQTRNekEzTkRBd01EZ3ZZV05qWlhOekxYUnZhMlZ1SWl3aVkyaGhiQ0k2SWtvMk5YVkpRWE5WYW1SS2RrNUdNRVp5Wmpkc2VWQnNUemRvYkVSSGJsZG9JaXdpYUdGdVpHeGxJam9pZDJseVpXRndjRG92THlVME1HRnNhV05sWDNkcGNtVkFkMmx5WlM1amIyMGlMQ0owWldGdElqb2lkMmx5WlNKOS40RURId3M5X3JlUmtSVEJaYmpTYWkwUlB3Z1RRX2RUbzFfWkxjZXlYbkZUWHVDeG4yM1g4bkFMZWhlMndwclA3ZUZlWFFJa3NGZ01BSTJCcWw5aXJCZyIsImNsaWVudF9pZCI6IndpcmVhcHA6Ly9xSGlETHNia1QyLXA5dVNKc21yWl9BITdmMzk5MDA4MzA3NDAwMDhAd2lyZS5jb20iLCJhcGlfdmVyc2lvbiI6NSwic2NvcGUiOiJ3aXJlX2NsaWVudF9pZCJ9._1iBdjC9MUNMi8nk1IvZTHpOgdcdejz-vg5RTFRW3Mg0BnvYicGSUlxMyFtEe_fQg5iIObSlwB0GrIqeCN3OAw"
   },
   "protected": {
     "alg": "EdDSA",
-    "kid": "https://stepca:32795/acme/wire/account/Z9pcI6iMTzA1TELu1INslFx6EthReoVE",
-    "nonce": "b3NIR3J1bkt3aUpBd3g5eHVoZ003SW9EZjlUNmp2ekE",
+    "kid": "https://stepca:32900/acme/wire/account/gNNR5cLt7T81dtC2zzehEvQKu4LAYByz",
+    "nonce": "ZzhkVmRwODVRdmhFakZJRlBRdUFTNGhwOER6eXFCdE4",
     "typ": "JWT",
-    "url": "https://stepca:32795/acme/wire/challenge/RO1lN0FiYIud1rZZ6E3uiY5eRdnjVE0o/0cSO2qsiV3grbpg9VN56vlr32RB4rLf4"
+    "url": "https://stepca:32900/acme/wire/challenge/PQMMQsFRGJ63rw5BJXcZRW5gdxiAnfza/xnRWBh033703AyPfEirQDytZggaHT2wt"
   }
 }
 ```
@@ -472,82 +471,89 @@ content-type: application/jose+json
 200
 cache-control: no-store
 content-type: application/json
-link: <https://stepca:32795/acme/wire/directory>;rel="index"
-link: <https://stepca:32795/acme/wire/authz/RO1lN0FiYIud1rZZ6E3uiY5eRdnjVE0o>;rel="up"
-location: https://stepca:32795/acme/wire/challenge/RO1lN0FiYIud1rZZ6E3uiY5eRdnjVE0o/0cSO2qsiV3grbpg9VN56vlr32RB4rLf4
-replay-nonce: czdDNEJXWWoyNXdiUldqVUNXdng0YTVDNlJ0eW52Slo
+link: <https://stepca:32900/acme/wire/directory>;rel="index"
+link: <https://stepca:32900/acme/wire/authz/PQMMQsFRGJ63rw5BJXcZRW5gdxiAnfza>;rel="up"
+location: https://stepca:32900/acme/wire/challenge/PQMMQsFRGJ63rw5BJXcZRW5gdxiAnfza/xnRWBh033703AyPfEirQDytZggaHT2wt
+replay-nonce: WUhXZ1h3bFFMR0VnYUZMendNa2VST20zUUFvTjNLaWw
 vary: Origin
 ```
 ```json
 {
   "type": "wire-dpop-01",
-  "url": "https://stepca:32795/acme/wire/challenge/RO1lN0FiYIud1rZZ6E3uiY5eRdnjVE0o/0cSO2qsiV3grbpg9VN56vlr32RB4rLf4",
+  "url": "https://stepca:32900/acme/wire/challenge/PQMMQsFRGJ63rw5BJXcZRW5gdxiAnfza/xnRWBh033703AyPfEirQDytZggaHT2wt",
   "status": "valid",
-  "token": "25xCjZl0wgv1jCU4Iu6HdtosB6yYvuSc",
-  "target": "http://wire.com:22504/clients/c7ddbab1a5225de1/access-token"
+  "token": "J65uIAsUjdJvNF0Frf7lyPlO7hlDGnWh",
+  "target": "http://wire.com:19803/clients/7f39900830740008/access-token"
 }
 ```
 ### Authenticate end user using OIDC Authorization Code with PKCE flow
 #### 18. OAUTH authorization request
 
 ```text
-code_verifier=R9M_8bjvKVlELoFzn0nDATKPgXYUMDRCoSUisjvhIXk&code_challenge=ZjX5sfDha3sGLAHczVPzdOjpbiQU85hu71U6EwbNLCA
+code_verifier=x3lfj-3RagsxL0n7kLzoCaJZDrLU-4rsXxGmsok_1g4&code_challenge=piqmPnP3ihrZBPs9tvlZ9q0tEBSq7Pw3ztPveHVwijU
 ```
 #### 19. OAUTH authorization request (auth code endpoint)
 ```http request
-GET http://dex:21126/dex/auth?response_type=code&client_id=wireapp&state=VFQsumy7yscaorqVgf2b2A&code_challenge=ZjX5sfDha3sGLAHczVPzdOjpbiQU85hu71U6EwbNLCA&code_challenge_method=S256&redirect_uri=http%3A%2F%2Fwire.com%3A22504%2Fcallback&scope=openid+profile&nonce=qPoDAGmqqAsndPvQNRWrBw
+GET http://keycloak:23675/realms/master/protocol/openid-connect/auth?response_type=code&client_id=wireapp&state=GBC-3xK2gUWZf3H9E4sOEg&code_challenge=piqmPnP3ihrZBPs9tvlZ9q0tEBSq7Pw3ztPveHVwijU&code_challenge_method=S256&redirect_uri=http%3A%2F%2Fwire.com%3A19803%2Fcallback&scope=openid+profile&claims=%7B%22id_token%22%3A%7B%22keyauth%22%3A%7B%22essential%22%3Atrue%2C%22value%22%3A%22J65uIAsUjdJvNF0Frf7lyPlO7hlDGnWh.6AywWmNTDyCxWG7YJAz3kRxeceA-t2XnmT0twAJJbj0%22%7D%7D%7D&nonce=9yPAxE6EiPliwDJd3LZSPA
 ```
 
-#### 20. OAUTH authorization code
-#### 21. OAUTH authorization code
-
-#### 22. OAUTH authorization code + verifier (token endpoint)
+#### 20. OAUTH authorization code + verifier (token endpoint)
 ```http request
-POST http://dex:21126/dex/token
+POST http://keycloak:23675/realms/master/protocol/openid-connect/token
 accept: application/json
 content-type: application/x-www-form-urlencoded
-authorization: Basic d2lyZWFwcDpRa3B2Y25aQ2JYcExOVFJ0ZFZkRVZ6bFNibmd4WTI1NA==
 ```
 ```text
-grant_type=authorization_code&code=ssp7ad5qmucretayb33r5ojun&code_verifier=R9M_8bjvKVlELoFzn0nDATKPgXYUMDRCoSUisjvhIXk&redirect_uri=http%3A%2F%2Fwire.com%3A22504%2Fcallback
+grant_type=authorization_code&code=40376dbb-b0dc-46b3-8b2a-6d8917a2898e.6dfbe005-854c-49cf-a2ec-8c7de826e00b.19c989f2-8db4-4ba1-b453-36ee3fd7e240&code_verifier=x3lfj-3RagsxL0n7kLzoCaJZDrLU-4rsXxGmsok_1g4&client_id=wireapp&redirect_uri=http%3A%2F%2Fwire.com%3A19803%2Fcallback
 ```
-#### 23. OAUTH access token
+#### 21. OAUTH access token
 
 ```text
 {
-  "access_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6Ijc5NmJkOTFkMGUwMWY2NmNjMDQyM2ZjZGRjYjEzZTIzZjIxNTJmMDMifQ.eyJpc3MiOiJodHRwOi8vZGV4OjIxMTI2L2RleCIsInN1YiI6IkNqcDNhWEpsWVhCd09pOHZTVkl3WDBsTmRFTlVUR2t6WVhNMVJXOURRbmRZWnlGak4yUmtZbUZpTVdFMU1qSTFaR1V4UUhkcGNtVXVZMjl0RWdSc1pHRnciLCJhdWQiOiJ3aXJlYXBwIiwiZXhwIjoxNzA1NDIyNDQ5LCJpYXQiOjE3MDUzMzYwNDksIm5vbmNlIjoicVBvREFHbXFxQXNuZFB2UU5SV3JCdyIsImF0X2hhc2giOiJrc3hwUXZRYU9FcFhRQXI2N2hoLXZRIiwibmFtZSI6IndpcmVhcHA6Ly8lNDBhbGljZV93aXJlQHdpcmUuY29tIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiQWxpY2UgU21pdGgifQ.UgDXIQKTjbeDzGps5sQKHk96QtiI2d2LNJsvfRbfMQCJ9-ZCQiC3WnGm98a5xLYovG8D7o-A8vNhyHrjpU_001wdm5wiu7vfUM5RqZKP7vVqLgTrVtXWiD4--tOxJRnw7VR3HkeURMC7djjsqxqAb6HnRw-43AWZzlDn5Fd5I9Qv3xx4KuUGTaqVkGaXX452AEUhFT5MmZriQw9SLRKVhSc0RyWbW7hZzKxD3iH2yaasjnDU1JqUwAbeGABAbprsd7rjLP2F_YtEbouEzrL8v2ByQMsQ6K6KIYyUhV-mCmYYrMS9sDgFq9dXSicyPbl9yrgEQLwJMDo0wwtg5LRiqw",
-  "expires_in": 86399,
-  "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6Ijc5NmJkOTFkMGUwMWY2NmNjMDQyM2ZjZGRjYjEzZTIzZjIxNTJmMDMifQ.eyJpc3MiOiJodHRwOi8vZGV4OjIxMTI2L2RleCIsInN1YiI6IkNqcDNhWEpsWVhCd09pOHZTVkl3WDBsTmRFTlVUR2t6WVhNMVJXOURRbmRZWnlGak4yUmtZbUZpTVdFMU1qSTFaR1V4UUhkcGNtVXVZMjl0RWdSc1pHRnciLCJhdWQiOiJ3aXJlYXBwIiwiZXhwIjoxNzA1NDIyNDQ5LCJpYXQiOjE3MDUzMzYwNDksIm5vbmNlIjoicVBvREFHbXFxQXNuZFB2UU5SV3JCdyIsImF0X2hhc2giOiIwWmNucDVyWTN5ZDJVU1ZzbHV4TTVnIiwiY19oYXNoIjoiZUVGN3RKNmY0dmVzOGlYaXc3RVVwZyIsIm5hbWUiOiJ3aXJlYXBwOi8vJTQwYWxpY2Vfd2lyZUB3aXJlLmNvbSIsInByZWZlcnJlZF91c2VybmFtZSI6IkFsaWNlIFNtaXRoIn0.D0TBJC-aR9h_KvyGzZbRL9FMfO3k_A5Sx7v_uYPwIQzA8H7-Xp0UKUiDSGChdiukpoyv0OIYTGpn99b-8Nu756rquZr-Dp0w5LeWgrQ4I7PTOvoxhcvYd6yNpLIUfgNqpCF7SdDppLTdpZpMyzmoESuz9qLgQQaas5S44o767ls2L_qn8xm_FST1G0tbn6UufdZtCiI2jog75A7JKAHfKqpv4ecmoCErz_7LXi9btBeXmeBWv69sjsw1sOdUNgL_mEJeZHZ75L7KjMZu2NiTVDtUFNs0vx1oyfKv0xwN40L_Igm8o9iS_GTNXLzK9Hb3Yw4ivd9NBsp9FPRSr7-rGw",
-  "token_type": "bearer"
+  "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJaeTBJVHF2YjJzVUVpdFlLUkk2NnNuQzh1bE9RV3M1ZUpqTjJPSHlIeldNIn0.eyJleHAiOjE3MDU0MTc4MjAsImlhdCI6MTcwNTQxNzc2MCwiYXV0aF90aW1lIjoxNzA1NDE3NzYwLCJqdGkiOiJiMWMyZmZhNi1mOGE2LTQ0ODAtODg3My1kM2Y4MjM4YTk5OWEiLCJpc3MiOiJodHRwOi8va2V5Y2xvYWs6MjM2NzUvcmVhbG1zL21hc3RlciIsImF1ZCI6ImFjY291bnQiLCJzdWIiOiJkNGRlYzQyNS0xNDM2LTQ1NzUtOGRiMS0yMDJjZjliZjAzMDQiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJ3aXJlYXBwIiwibm9uY2UiOiI5eVBBeEU2RWlQbGl3REpkM0xaU1BBIiwic2Vzc2lvbl9zdGF0ZSI6IjZkZmJlMDA1LTg1NGMtNDljZi1hMmVjLThjN2RlODI2ZTAwYiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovL3dpcmUuY29tOjE5ODAzIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLW1hc3RlciIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXX0sInJlc291cmNlX2FjY2VzcyI6eyJhY2NvdW50Ijp7InJvbGVzIjpbIm1hbmFnZS1hY2NvdW50IiwibWFuYWdlLWFjY291bnQtbGlua3MiLCJ2aWV3LXByb2ZpbGUiXX19LCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIiwic2lkIjoiNmRmYmUwMDUtODU0Yy00OWNmLWEyZWMtOGM3ZGU4MjZlMDBiIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsIm5hbWUiOiJBbGljZSBTbWl0aCIsInByZWZlcnJlZF91c2VybmFtZSI6IndpcmVhcHA6Ly8lNDBhbGljZV93aXJlQHdpcmUuY29tIiwiZ2l2ZW5fbmFtZSI6IkFsaWNlIiwiZmFtaWx5X25hbWUiOiJTbWl0aCIsImVtYWlsIjoiYWxpY2VzbWl0aEB3aXJlLmNvbSJ9.XNfAPWwEjvqtNwP4Q2m1Bkoy3BrHKTRrVUsPYJgCpI_SY-Sf43i1K4Hes5k-76gCWlRikzddl_hbKBsykemntw4wnMw5WYlBZ9n0FtdZdcy2c8Z3sijpBy3nnw2cpNyy5LYYyOpOCjABkd5zE1Y8BBDXgxJxubGTfsD45mP3fporS9aqWYHn9wL2w8-nyCxitiMt6GkvS7_-6Q0JGka6tOueEHLDOltBind0kfM409Vtwp_xvCrpvl6qQIXQpdq3zwiHtC4h3thpQniVWGLOBBtTqJDnfVp684xt6yhbrei9nLJetqmzoGTj2Zy3mMvttfdLo8_cSZaBhfNOhAv96Q",
+  "expires_in": 60,
+  "id_token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJaeTBJVHF2YjJzVUVpdFlLUkk2NnNuQzh1bE9RV3M1ZUpqTjJPSHlIeldNIn0.eyJleHAiOjE3MDU0MTc4MjAsImlhdCI6MTcwNTQxNzc2MCwiYXV0aF90aW1lIjoxNzA1NDE3NzYwLCJqdGkiOiJlOWI3ZWY5ZC1mNTA5LTQwNGEtOGRmNS1lNzJkOWYyNGUwNTAiLCJpc3MiOiJodHRwOi8va2V5Y2xvYWs6MjM2NzUvcmVhbG1zL21hc3RlciIsImF1ZCI6IndpcmVhcHAiLCJzdWIiOiJkNGRlYzQyNS0xNDM2LTQ1NzUtOGRiMS0yMDJjZjliZjAzMDQiLCJ0eXAiOiJJRCIsImF6cCI6IndpcmVhcHAiLCJub25jZSI6Ijl5UEF4RTZFaVBsaXdESmQzTFpTUEEiLCJzZXNzaW9uX3N0YXRlIjoiNmRmYmUwMDUtODU0Yy00OWNmLWEyZWMtOGM3ZGU4MjZlMDBiIiwiYXRfaGFzaCI6IlloYVhWZWhGQ0NLaFJ6T0t1akdTOFEiLCJhY3IiOiIxIiwic2lkIjoiNmRmYmUwMDUtODU0Yy00OWNmLWEyZWMtOGM3ZGU4MjZlMDBiIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsIm5hbWUiOiJBbGljZSBTbWl0aCIsInByZWZlcnJlZF91c2VybmFtZSI6IndpcmVhcHA6Ly8lNDBhbGljZV93aXJlQHdpcmUuY29tIiwia2V5YXV0aCI6Iko2NXVJQXNVamRKdk5GMEZyZjdseVBsTzdobERHbldoLjZBeXdXbU5URHlDeFdHN1lKQXoza1J4ZWNlQS10MlhubVQwdHdBSkpiajAiLCJnaXZlbl9uYW1lIjoiQWxpY2UiLCJmYW1pbHlfbmFtZSI6IlNtaXRoIiwiZW1haWwiOiJhbGljZXNtaXRoQHdpcmUuY29tIn0.jFlx8sGXFdLyQaxt03JaAqKr9E03bBtk8jhiyJKm9yQ14A9BOOASm7EcSkTtX3DEnUnz_BHzM_Qgq0PHBiSbPAxQrO7OHFu8UCeZqe_tTq-b5UpDPyEJvaxVMWOTzy5rB7sDTuLBgrBW41d2SmCqwNhhg0r0ib6p8qfSxhM1nNZpxilWI7b_LZybWmAhdWKq6yfJeG_yGj1UuXkh2M79vP4hueFJ8LznfCF5dUsDVsazLlGwSacMv1Ku5hgZJzDkI9BGK4zbF0gwiPVtd7KWGwhD_CUpJ7HvBvapYSwqibbFf-AcFOSjjdG6bH_aBARa0kAC3ZHtOXORjrddkCY41Q",
+  "not-before-policy": 0,
+  "refresh_expires_in": 1800,
+  "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIwMDJkOWFkZi1kOGJiLTQ0MjctODViNy0xNGFmOWIzODg4ZTUifQ.eyJleHAiOjE3MDU0MTk1NjAsImlhdCI6MTcwNTQxNzc2MCwianRpIjoiOThmZWRiMDEtYzVlZC00YTE1LWE4MzUtZmNkYWJiODdhYmFlIiwiaXNzIjoiaHR0cDovL2tleWNsb2FrOjIzNjc1L3JlYWxtcy9tYXN0ZXIiLCJhdWQiOiJodHRwOi8va2V5Y2xvYWs6MjM2NzUvcmVhbG1zL21hc3RlciIsInN1YiI6ImQ0ZGVjNDI1LTE0MzYtNDU3NS04ZGIxLTIwMmNmOWJmMDMwNCIsInR5cCI6IlJlZnJlc2giLCJhenAiOiJ3aXJlYXBwIiwibm9uY2UiOiI5eVBBeEU2RWlQbGl3REpkM0xaU1BBIiwic2Vzc2lvbl9zdGF0ZSI6IjZkZmJlMDA1LTg1NGMtNDljZi1hMmVjLThjN2RlODI2ZTAwYiIsInNjb3BlIjoib3BlbmlkIGVtYWlsIHByb2ZpbGUiLCJzaWQiOiI2ZGZiZTAwNS04NTRjLTQ5Y2YtYTJlYy04YzdkZTgyNmUwMGIifQ.WPQw1uCgdZn9_7n2KVYMHaBNusPAr-5ze5339O7wrAs",
+  "scope": "openid email profile",
+  "session_state": "6dfbe005-854c-49cf-a2ec-8c7de826e00b",
+  "token_type": "Bearer"
 }
 ```
-```text
-eyJhbGciOiJSUzI1NiIsImtpZCI6Ijc5NmJkOTFkMGUwMWY2NmNjMDQyM2ZjZGRjYjEzZTIzZjIxNTJmMDMifQ.eyJpc3MiOiJodHRwOi8vZGV4OjIxMTI2L2RleCIsInN1YiI6IkNqcDNhWEpsWVhCd09pOHZTVkl3WDBsTmRFTlVUR2t6WVhNMVJXOURRbmRZWnlGak4yUmtZbUZpTVdFMU1qSTFaR1V4UUhkcGNtVXVZMjl0RWdSc1pHRnciLCJhdWQiOiJ3aXJlYXBwIiwiZXhwIjoxNzA1NDIyNDQ5LCJpYXQiOjE3MDUzMzYwNDksIm5vbmNlIjoicVBvREFHbXFxQXNuZFB2UU5SV3JCdyIsImF0X2hhc2giOiIwWmNucDVyWTN5ZDJVU1ZzbHV4TTVnIiwiY19oYXNoIjoiZUVGN3RKNmY0dmVzOGlYaXc3RVVwZyIsIm5hbWUiOiJ3aXJlYXBwOi8vJTQwYWxpY2Vfd2lyZUB3aXJlLmNvbSIsInByZWZlcnJlZF91c2VybmFtZSI6IkFsaWNlIFNtaXRoIn0.D0TBJC-aR9h_KvyGzZbRL9FMfO3k_A5Sx7v_uYPwIQzA8H7-Xp0UKUiDSGChdiukpoyv0OIYTGpn99b-8Nu756rquZr-Dp0w5LeWgrQ4I7PTOvoxhcvYd6yNpLIUfgNqpCF7SdDppLTdpZpMyzmoESuz9qLgQQaas5S44o767ls2L_qn8xm_FST1G0tbn6UufdZtCiI2jog75A7JKAHfKqpv4ecmoCErz_7LXi9btBeXmeBWv69sjsw1sOdUNgL_mEJeZHZ75L7KjMZu2NiTVDtUFNs0vx1oyfKv0xwN40L_Igm8o9iS_GTNXLzK9Hb3Yw4ivd9NBsp9FPRSr7-rGw
-```
-#### 24. validate oidc challenge (userId + displayName)
 
 <details>
-<summary><b>Id token</b></summary>
+<summary><b>OAuth Access token</b></summary>
 
-See it on [jwt.io](https://jwt.io/#id_token=eyJhbGciOiJSUzI1NiIsImtpZCI6Ijc5NmJkOTFkMGUwMWY2NmNjMDQyM2ZjZGRjYjEzZTIzZjIxNTJmMDMifQ.eyJpc3MiOiJodHRwOi8vZGV4OjIxMTI2L2RleCIsInN1YiI6IkNqcDNhWEpsWVhCd09pOHZTVkl3WDBsTmRFTlVUR2t6WVhNMVJXOURRbmRZWnlGak4yUmtZbUZpTVdFMU1qSTFaR1V4UUhkcGNtVXVZMjl0RWdSc1pHRnciLCJhdWQiOiJ3aXJlYXBwIiwiZXhwIjoxNzA1NDIyNDQ5LCJpYXQiOjE3MDUzMzYwNDksIm5vbmNlIjoicVBvREFHbXFxQXNuZFB2UU5SV3JCdyIsImF0X2hhc2giOiIwWmNucDVyWTN5ZDJVU1ZzbHV4TTVnIiwiY19oYXNoIjoiZUVGN3RKNmY0dmVzOGlYaXc3RVVwZyIsIm5hbWUiOiJ3aXJlYXBwOi8vJTQwYWxpY2Vfd2lyZUB3aXJlLmNvbSIsInByZWZlcnJlZF91c2VybmFtZSI6IkFsaWNlIFNtaXRoIn0.D0TBJC-aR9h_KvyGzZbRL9FMfO3k_A5Sx7v_uYPwIQzA8H7-Xp0UKUiDSGChdiukpoyv0OIYTGpn99b-8Nu756rquZr-Dp0w5LeWgrQ4I7PTOvoxhcvYd6yNpLIUfgNqpCF7SdDppLTdpZpMyzmoESuz9qLgQQaas5S44o767ls2L_qn8xm_FST1G0tbn6UufdZtCiI2jog75A7JKAHfKqpv4ecmoCErz_7LXi9btBeXmeBWv69sjsw1sOdUNgL_mEJeZHZ75L7KjMZu2NiTVDtUFNs0vx1oyfKv0xwN40L_Igm8o9iS_GTNXLzK9Hb3Yw4ivd9NBsp9FPRSr7-rGw)
+See it on [jwt.io](https://jwt.io/#id_token=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJaeTBJVHF2YjJzVUVpdFlLUkk2NnNuQzh1bE9RV3M1ZUpqTjJPSHlIeldNIn0.eyJleHAiOjE3MDU0MTc4MjAsImlhdCI6MTcwNTQxNzc2MCwiYXV0aF90aW1lIjoxNzA1NDE3NzYwLCJqdGkiOiJiMWMyZmZhNi1mOGE2LTQ0ODAtODg3My1kM2Y4MjM4YTk5OWEiLCJpc3MiOiJodHRwOi8va2V5Y2xvYWs6MjM2NzUvcmVhbG1zL21hc3RlciIsImF1ZCI6ImFjY291bnQiLCJzdWIiOiJkNGRlYzQyNS0xNDM2LTQ1NzUtOGRiMS0yMDJjZjliZjAzMDQiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJ3aXJlYXBwIiwibm9uY2UiOiI5eVBBeEU2RWlQbGl3REpkM0xaU1BBIiwic2Vzc2lvbl9zdGF0ZSI6IjZkZmJlMDA1LTg1NGMtNDljZi1hMmVjLThjN2RlODI2ZTAwYiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovL3dpcmUuY29tOjE5ODAzIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLW1hc3RlciIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXX0sInJlc291cmNlX2FjY2VzcyI6eyJhY2NvdW50Ijp7InJvbGVzIjpbIm1hbmFnZS1hY2NvdW50IiwibWFuYWdlLWFjY291bnQtbGlua3MiLCJ2aWV3LXByb2ZpbGUiXX19LCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIiwic2lkIjoiNmRmYmUwMDUtODU0Yy00OWNmLWEyZWMtOGM3ZGU4MjZlMDBiIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsIm5hbWUiOiJBbGljZSBTbWl0aCIsInByZWZlcnJlZF91c2VybmFtZSI6IndpcmVhcHA6Ly8lNDBhbGljZV93aXJlQHdpcmUuY29tIiwiZ2l2ZW5fbmFtZSI6IkFsaWNlIiwiZmFtaWx5X25hbWUiOiJTbWl0aCIsImVtYWlsIjoiYWxpY2VzbWl0aEB3aXJlLmNvbSJ9.XNfAPWwEjvqtNwP4Q2m1Bkoy3BrHKTRrVUsPYJgCpI_SY-Sf43i1K4Hes5k-76gCWlRikzddl_hbKBsykemntw4wnMw5WYlBZ9n0FtdZdcy2c8Z3sijpBy3nnw2cpNyy5LYYyOpOCjABkd5zE1Y8BBDXgxJxubGTfsD45mP3fporS9aqWYHn9wL2w8-nyCxitiMt6GkvS7_-6Q0JGka6tOueEHLDOltBind0kfM409Vtwp_xvCrpvl6qQIXQpdq3zwiHtC4h3thpQniVWGLOBBtTqJDnfVp684xt6yhbrei9nLJetqmzoGTj2Zy3mMvttfdLo8_cSZaBhfNOhAv96Q)
 
 Raw:
 ```text
-eyJhbGciOiJSUzI1NiIsImtpZCI6Ijc5NmJkOTFkMGUwMWY2NmNjMDQyM2ZjZGRj
-YjEzZTIzZjIxNTJmMDMifQ.eyJpc3MiOiJodHRwOi8vZGV4OjIxMTI2L2RleCIsI
-nN1YiI6IkNqcDNhWEpsWVhCd09pOHZTVkl3WDBsTmRFTlVUR2t6WVhNMVJXOURRb
-mRZWnlGak4yUmtZbUZpTVdFMU1qSTFaR1V4UUhkcGNtVXVZMjl0RWdSc1pHRnciL
-CJhdWQiOiJ3aXJlYXBwIiwiZXhwIjoxNzA1NDIyNDQ5LCJpYXQiOjE3MDUzMzYwN
-DksIm5vbmNlIjoicVBvREFHbXFxQXNuZFB2UU5SV3JCdyIsImF0X2hhc2giOiIwW
-mNucDVyWTN5ZDJVU1ZzbHV4TTVnIiwiY19oYXNoIjoiZUVGN3RKNmY0dmVzOGlYa
-Xc3RVVwZyIsIm5hbWUiOiJ3aXJlYXBwOi8vJTQwYWxpY2Vfd2lyZUB3aXJlLmNvb
-SIsInByZWZlcnJlZF91c2VybmFtZSI6IkFsaWNlIFNtaXRoIn0.D0TBJC-aR9h_K
-vyGzZbRL9FMfO3k_A5Sx7v_uYPwIQzA8H7-Xp0UKUiDSGChdiukpoyv0OIYTGpn9
-9b-8Nu756rquZr-Dp0w5LeWgrQ4I7PTOvoxhcvYd6yNpLIUfgNqpCF7SdDppLTdp
-ZpMyzmoESuz9qLgQQaas5S44o767ls2L_qn8xm_FST1G0tbn6UufdZtCiI2jog75
-A7JKAHfKqpv4ecmoCErz_7LXi9btBeXmeBWv69sjsw1sOdUNgL_mEJeZHZ75L7Kj
-MZu2NiTVDtUFNs0vx1oyfKv0xwN40L_Igm8o9iS_GTNXLzK9Hb3Yw4ivd9NBsp9F
-PRSr7-rGw
+eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJaeTBJVHF2YjJz
+VUVpdFlLUkk2NnNuQzh1bE9RV3M1ZUpqTjJPSHlIeldNIn0.eyJleHAiOjE3MDU0
+MTc4MjAsImlhdCI6MTcwNTQxNzc2MCwiYXV0aF90aW1lIjoxNzA1NDE3NzYwLCJq
+dGkiOiJiMWMyZmZhNi1mOGE2LTQ0ODAtODg3My1kM2Y4MjM4YTk5OWEiLCJpc3Mi
+OiJodHRwOi8va2V5Y2xvYWs6MjM2NzUvcmVhbG1zL21hc3RlciIsImF1ZCI6ImFj
+Y291bnQiLCJzdWIiOiJkNGRlYzQyNS0xNDM2LTQ1NzUtOGRiMS0yMDJjZjliZjAz
+MDQiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJ3aXJlYXBwIiwibm9uY2UiOiI5eVBB
+eEU2RWlQbGl3REpkM0xaU1BBIiwic2Vzc2lvbl9zdGF0ZSI6IjZkZmJlMDA1LTg1
+NGMtNDljZi1hMmVjLThjN2RlODI2ZTAwYiIsImFjciI6IjEiLCJhbGxvd2VkLW9y
+aWdpbnMiOlsiaHR0cDovL3dpcmUuY29tOjE5ODAzIl0sInJlYWxtX2FjY2VzcyI6
+eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLW1hc3RlciIsIm9mZmxpbmVfYWNjZXNz
+IiwidW1hX2F1dGhvcml6YXRpb24iXX0sInJlc291cmNlX2FjY2VzcyI6eyJhY2Nv
+dW50Ijp7InJvbGVzIjpbIm1hbmFnZS1hY2NvdW50IiwibWFuYWdlLWFjY291bnQt
+bGlua3MiLCJ2aWV3LXByb2ZpbGUiXX19LCJzY29wZSI6Im9wZW5pZCBlbWFpbCBw
+cm9maWxlIiwic2lkIjoiNmRmYmUwMDUtODU0Yy00OWNmLWEyZWMtOGM3ZGU4MjZl
+MDBiIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsIm5hbWUiOiJBbGljZSBTbWl0aCIs
+InByZWZlcnJlZF91c2VybmFtZSI6IndpcmVhcHA6Ly8lNDBhbGljZV93aXJlQHdp
+cmUuY29tIiwiZ2l2ZW5fbmFtZSI6IkFsaWNlIiwiZmFtaWx5X25hbWUiOiJTbWl0
+aCIsImVtYWlsIjoiYWxpY2VzbWl0aEB3aXJlLmNvbSJ9.XNfAPWwEjvqtNwP4Q2m
+1Bkoy3BrHKTRrVUsPYJgCpI_SY-Sf43i1K4Hes5k-76gCWlRikzddl_hbKBsykem
+ntw4wnMw5WYlBZ9n0FtdZdcy2c8Z3sijpBy3nnw2cpNyy5LYYyOpOCjABkd5zE1Y
+8BBDXgxJxubGTfsD45mP3fporS9aqWYHn9wL2w8-nyCxitiMt6GkvS7_-6Q0JGka
+6tOueEHLDOltBind0kfM409Vtwp_xvCrpvl6qQIXQpdq3zwiHtC4h3thpQniVWGL
+OBBtTqJDnfVp684xt6yhbrei9nLJetqmzoGTj2Zy3mMvttfdLo8_cSZaBhfNOhAv
+96Q
 ```
 
 Decoded:
@@ -555,36 +561,217 @@ Decoded:
 ```json
 {
   "alg": "RS256",
-  "kid": "796bd91d0e01f66cc0423fcddcb13e23f2152f03"
+  "kid": "Zy0ITqvb2sUEitYKRI66snC8ulOQWs5eJjN2OHyHzWM",
+  "typ": "JWT"
 }
 ```
 
 ```json
 {
-  "at_hash": "0Zcnp5rY3yd2USVsluxM5g",
-  "aud": "wireapp",
-  "c_hash": "eEF7tJ6f4ves8iXiw7EUpg",
-  "exp": 1705422449,
-  "iat": 1705336049,
-  "iss": "http://dex:21126/dex",
-  "name": "wireapp://%40alice_wire@wire.com",
-  "nonce": "qPoDAGmqqAsndPvQNRWrBw",
-  "preferred_username": "Alice Smith",
-  "sub": "Cjp3aXJlYXBwOi8vSVIwX0lNdENUTGkzYXM1RW9DQndYZyFjN2RkYmFiMWE1MjI1ZGUxQHdpcmUuY29tEgRsZGFw"
+  "acr": "1",
+  "allowed-origins": [
+    "http://wire.com:19803"
+  ],
+  "aud": "account",
+  "auth_time": 1705417760,
+  "azp": "wireapp",
+  "email": "alicesmith@wire.com",
+  "email_verified": true,
+  "exp": 1705417820,
+  "family_name": "Smith",
+  "given_name": "Alice",
+  "iat": 1705417760,
+  "iss": "http://keycloak:23675/realms/master",
+  "jti": "b1c2ffa6-f8a6-4480-8873-d3f8238a999a",
+  "name": "Alice Smith",
+  "nonce": "9yPAxE6EiPliwDJd3LZSPA",
+  "preferred_username": "wireapp://%40alice_wire@wire.com",
+  "realm_access": {
+    "roles": [
+      "default-roles-master",
+      "offline_access",
+      "uma_authorization"
+    ]
+  },
+  "resource_access": {
+    "account": {
+      "roles": [
+        "manage-account",
+        "manage-account-links",
+        "view-profile"
+      ]
+    }
+  },
+  "scope": "openid email profile",
+  "session_state": "6dfbe005-854c-49cf-a2ec-8c7de826e00b",
+  "sid": "6dfbe005-854c-49cf-a2ec-8c7de826e00b",
+  "sub": "d4dec425-1436-4575-8db1-202cf9bf0304",
+  "typ": "Bearer"
 }
 ```
 
 
-✅ Signature Verified with key:
+❌ Invalid Signature with key:
 ```text
 -----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs7+pXsw+DMrHK9OpLcl9
-D60jRk6gXPqCd3+niRZ25QO0RSjtq1cTcAu9yN6SwZHxQsfWo+2DQEiJ6KRG2bHj
-OdCHB/LNq8Og8I66j2trebZW4i8GWxKcIrhY2xo6WAxeKDfXJJsrZxAdAX9MGbW5
-gvlLqwbQD+BEcO9ohu0q03rE5an2jDvXvo7JHHzQfcj4uKnjTwEBJVyvjLRQTHzU
-GriXF8sV1ngF5WD3BmWbWzOJO2cib8pi2idPps0kgNXPA/ZEg97XCjYZtIBFib4W
-bzrTOKi+dn/MgdgVKvdKoy2VtgpoprERKzNWdgt0hLarkbeorIClo/749gxVeQzv
-ywIDAQAB
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1S175FnO1SBTJ0kjjGKn
+J6gzdOZw10u5VgugG7lwreyTbVAni8rDne2puFX+22kwTlu1GqhuMxMRTOo9iTI/
+yplRIRQbR5jTmCpfT7x5f79cn6AQeX5uBEfvSFLHVude8NSJbGInWJpGzF2tJ8KZ
+w3ZphwAUjhFEqLBAk1fkxW4t5oY3+o7wUnYDJJNAmNGZgJUqkXLWL/hkGdIDHyaq
+DivmLawRJA6oJPKzH45KbZ4c3KGv0mC++dgTU4qWr7Qvf0r4Drsu7jCQno1KXhon
+fWhuHt1RQKws8vtmbKVUOoXxoXyJpVp5koVTj/tCCafLfdhi4weODpk73Jkcd5Ci
+3QIDAQAB
+-----END PUBLIC KEY-----
+```
+
+</details>
+
+
+
+<details>
+<summary><b>OAuth Refresh token</b></summary>
+
+See it on [jwt.io](https://jwt.io/#id_token=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIwMDJkOWFkZi1kOGJiLTQ0MjctODViNy0xNGFmOWIzODg4ZTUifQ.eyJleHAiOjE3MDU0MTk1NjAsImlhdCI6MTcwNTQxNzc2MCwianRpIjoiOThmZWRiMDEtYzVlZC00YTE1LWE4MzUtZmNkYWJiODdhYmFlIiwiaXNzIjoiaHR0cDovL2tleWNsb2FrOjIzNjc1L3JlYWxtcy9tYXN0ZXIiLCJhdWQiOiJodHRwOi8va2V5Y2xvYWs6MjM2NzUvcmVhbG1zL21hc3RlciIsInN1YiI6ImQ0ZGVjNDI1LTE0MzYtNDU3NS04ZGIxLTIwMmNmOWJmMDMwNCIsInR5cCI6IlJlZnJlc2giLCJhenAiOiJ3aXJlYXBwIiwibm9uY2UiOiI5eVBBeEU2RWlQbGl3REpkM0xaU1BBIiwic2Vzc2lvbl9zdGF0ZSI6IjZkZmJlMDA1LTg1NGMtNDljZi1hMmVjLThjN2RlODI2ZTAwYiIsInNjb3BlIjoib3BlbmlkIGVtYWlsIHByb2ZpbGUiLCJzaWQiOiI2ZGZiZTAwNS04NTRjLTQ5Y2YtYTJlYy04YzdkZTgyNmUwMGIifQ.WPQw1uCgdZn9_7n2KVYMHaBNusPAr-5ze5339O7wrAs)
+
+Raw:
+```text
+eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIwMDJkOWFkZi1k
+OGJiLTQ0MjctODViNy0xNGFmOWIzODg4ZTUifQ.eyJleHAiOjE3MDU0MTk1NjAsI
+mlhdCI6MTcwNTQxNzc2MCwianRpIjoiOThmZWRiMDEtYzVlZC00YTE1LWE4MzUtZ
+mNkYWJiODdhYmFlIiwiaXNzIjoiaHR0cDovL2tleWNsb2FrOjIzNjc1L3JlYWxtc
+y9tYXN0ZXIiLCJhdWQiOiJodHRwOi8va2V5Y2xvYWs6MjM2NzUvcmVhbG1zL21hc
+3RlciIsInN1YiI6ImQ0ZGVjNDI1LTE0MzYtNDU3NS04ZGIxLTIwMmNmOWJmMDMwN
+CIsInR5cCI6IlJlZnJlc2giLCJhenAiOiJ3aXJlYXBwIiwibm9uY2UiOiI5eVBBe
+EU2RWlQbGl3REpkM0xaU1BBIiwic2Vzc2lvbl9zdGF0ZSI6IjZkZmJlMDA1LTg1N
+GMtNDljZi1hMmVjLThjN2RlODI2ZTAwYiIsInNjb3BlIjoib3BlbmlkIGVtYWlsI
+HByb2ZpbGUiLCJzaWQiOiI2ZGZiZTAwNS04NTRjLTQ5Y2YtYTJlYy04YzdkZTgyN
+mUwMGIifQ.WPQw1uCgdZn9_7n2KVYMHaBNusPAr-5ze5339O7wrAs
+```
+
+Decoded:
+
+```json
+{
+  "alg": "HS256",
+  "kid": "002d9adf-d8bb-4427-85b7-14af9b3888e5",
+  "typ": "JWT"
+}
+```
+
+```json
+{
+  "aud": "http://keycloak:23675/realms/master",
+  "azp": "wireapp",
+  "exp": 1705419560,
+  "iat": 1705417760,
+  "iss": "http://keycloak:23675/realms/master",
+  "jti": "98fedb01-c5ed-4a15-a835-fcdabb87abae",
+  "nonce": "9yPAxE6EiPliwDJd3LZSPA",
+  "scope": "openid email profile",
+  "session_state": "6dfbe005-854c-49cf-a2ec-8c7de826e00b",
+  "sid": "6dfbe005-854c-49cf-a2ec-8c7de826e00b",
+  "sub": "d4dec425-1436-4575-8db1-202cf9bf0304",
+  "typ": "Refresh"
+}
+```
+
+
+❌ Invalid Signature with key:
+```text
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1S175FnO1SBTJ0kjjGKn
+J6gzdOZw10u5VgugG7lwreyTbVAni8rDne2puFX+22kwTlu1GqhuMxMRTOo9iTI/
+yplRIRQbR5jTmCpfT7x5f79cn6AQeX5uBEfvSFLHVude8NSJbGInWJpGzF2tJ8KZ
+w3ZphwAUjhFEqLBAk1fkxW4t5oY3+o7wUnYDJJNAmNGZgJUqkXLWL/hkGdIDHyaq
+DivmLawRJA6oJPKzH45KbZ4c3KGv0mC++dgTU4qWr7Qvf0r4Drsu7jCQno1KXhon
+fWhuHt1RQKws8vtmbKVUOoXxoXyJpVp5koVTj/tCCafLfdhi4weODpk73Jkcd5Ci
+3QIDAQAB
+-----END PUBLIC KEY-----
+```
+
+</details>
+
+
+#### 22. validate oidc challenge (userId + displayName)
+
+<details>
+<summary><b>OIDC Id token</b></summary>
+
+See it on [jwt.io](https://jwt.io/#id_token=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJaeTBJVHF2YjJzVUVpdFlLUkk2NnNuQzh1bE9RV3M1ZUpqTjJPSHlIeldNIn0.eyJleHAiOjE3MDU0MTc4MjAsImlhdCI6MTcwNTQxNzc2MCwiYXV0aF90aW1lIjoxNzA1NDE3NzYwLCJqdGkiOiJlOWI3ZWY5ZC1mNTA5LTQwNGEtOGRmNS1lNzJkOWYyNGUwNTAiLCJpc3MiOiJodHRwOi8va2V5Y2xvYWs6MjM2NzUvcmVhbG1zL21hc3RlciIsImF1ZCI6IndpcmVhcHAiLCJzdWIiOiJkNGRlYzQyNS0xNDM2LTQ1NzUtOGRiMS0yMDJjZjliZjAzMDQiLCJ0eXAiOiJJRCIsImF6cCI6IndpcmVhcHAiLCJub25jZSI6Ijl5UEF4RTZFaVBsaXdESmQzTFpTUEEiLCJzZXNzaW9uX3N0YXRlIjoiNmRmYmUwMDUtODU0Yy00OWNmLWEyZWMtOGM3ZGU4MjZlMDBiIiwiYXRfaGFzaCI6IlloYVhWZWhGQ0NLaFJ6T0t1akdTOFEiLCJhY3IiOiIxIiwic2lkIjoiNmRmYmUwMDUtODU0Yy00OWNmLWEyZWMtOGM3ZGU4MjZlMDBiIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsIm5hbWUiOiJBbGljZSBTbWl0aCIsInByZWZlcnJlZF91c2VybmFtZSI6IndpcmVhcHA6Ly8lNDBhbGljZV93aXJlQHdpcmUuY29tIiwia2V5YXV0aCI6Iko2NXVJQXNVamRKdk5GMEZyZjdseVBsTzdobERHbldoLjZBeXdXbU5URHlDeFdHN1lKQXoza1J4ZWNlQS10MlhubVQwdHdBSkpiajAiLCJnaXZlbl9uYW1lIjoiQWxpY2UiLCJmYW1pbHlfbmFtZSI6IlNtaXRoIiwiZW1haWwiOiJhbGljZXNtaXRoQHdpcmUuY29tIn0.jFlx8sGXFdLyQaxt03JaAqKr9E03bBtk8jhiyJKm9yQ14A9BOOASm7EcSkTtX3DEnUnz_BHzM_Qgq0PHBiSbPAxQrO7OHFu8UCeZqe_tTq-b5UpDPyEJvaxVMWOTzy5rB7sDTuLBgrBW41d2SmCqwNhhg0r0ib6p8qfSxhM1nNZpxilWI7b_LZybWmAhdWKq6yfJeG_yGj1UuXkh2M79vP4hueFJ8LznfCF5dUsDVsazLlGwSacMv1Ku5hgZJzDkI9BGK4zbF0gwiPVtd7KWGwhD_CUpJ7HvBvapYSwqibbFf-AcFOSjjdG6bH_aBARa0kAC3ZHtOXORjrddkCY41Q)
+
+Raw:
+```text
+eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJaeTBJVHF2YjJz
+VUVpdFlLUkk2NnNuQzh1bE9RV3M1ZUpqTjJPSHlIeldNIn0.eyJleHAiOjE3MDU0
+MTc4MjAsImlhdCI6MTcwNTQxNzc2MCwiYXV0aF90aW1lIjoxNzA1NDE3NzYwLCJq
+dGkiOiJlOWI3ZWY5ZC1mNTA5LTQwNGEtOGRmNS1lNzJkOWYyNGUwNTAiLCJpc3Mi
+OiJodHRwOi8va2V5Y2xvYWs6MjM2NzUvcmVhbG1zL21hc3RlciIsImF1ZCI6Indp
+cmVhcHAiLCJzdWIiOiJkNGRlYzQyNS0xNDM2LTQ1NzUtOGRiMS0yMDJjZjliZjAz
+MDQiLCJ0eXAiOiJJRCIsImF6cCI6IndpcmVhcHAiLCJub25jZSI6Ijl5UEF4RTZF
+aVBsaXdESmQzTFpTUEEiLCJzZXNzaW9uX3N0YXRlIjoiNmRmYmUwMDUtODU0Yy00
+OWNmLWEyZWMtOGM3ZGU4MjZlMDBiIiwiYXRfaGFzaCI6IlloYVhWZWhGQ0NLaFJ6
+T0t1akdTOFEiLCJhY3IiOiIxIiwic2lkIjoiNmRmYmUwMDUtODU0Yy00OWNmLWEy
+ZWMtOGM3ZGU4MjZlMDBiIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsIm5hbWUiOiJB
+bGljZSBTbWl0aCIsInByZWZlcnJlZF91c2VybmFtZSI6IndpcmVhcHA6Ly8lNDBh
+bGljZV93aXJlQHdpcmUuY29tIiwia2V5YXV0aCI6Iko2NXVJQXNVamRKdk5GMEZy
+ZjdseVBsTzdobERHbldoLjZBeXdXbU5URHlDeFdHN1lKQXoza1J4ZWNlQS10Mlhu
+bVQwdHdBSkpiajAiLCJnaXZlbl9uYW1lIjoiQWxpY2UiLCJmYW1pbHlfbmFtZSI6
+IlNtaXRoIiwiZW1haWwiOiJhbGljZXNtaXRoQHdpcmUuY29tIn0.jFlx8sGXFdLy
+Qaxt03JaAqKr9E03bBtk8jhiyJKm9yQ14A9BOOASm7EcSkTtX3DEnUnz_BHzM_Qg
+q0PHBiSbPAxQrO7OHFu8UCeZqe_tTq-b5UpDPyEJvaxVMWOTzy5rB7sDTuLBgrBW
+41d2SmCqwNhhg0r0ib6p8qfSxhM1nNZpxilWI7b_LZybWmAhdWKq6yfJeG_yGj1U
+uXkh2M79vP4hueFJ8LznfCF5dUsDVsazLlGwSacMv1Ku5hgZJzDkI9BGK4zbF0gw
+iPVtd7KWGwhD_CUpJ7HvBvapYSwqibbFf-AcFOSjjdG6bH_aBARa0kAC3ZHtOXOR
+jrddkCY41Q
+```
+
+Decoded:
+
+```json
+{
+  "alg": "RS256",
+  "kid": "Zy0ITqvb2sUEitYKRI66snC8ulOQWs5eJjN2OHyHzWM",
+  "typ": "JWT"
+}
+```
+
+```json
+{
+  "acr": "1",
+  "at_hash": "YhaXVehFCCKhRzOKujGS8Q",
+  "aud": "wireapp",
+  "auth_time": 1705417760,
+  "azp": "wireapp",
+  "email": "alicesmith@wire.com",
+  "email_verified": true,
+  "exp": 1705417820,
+  "family_name": "Smith",
+  "given_name": "Alice",
+  "iat": 1705417760,
+  "iss": "http://keycloak:23675/realms/master",
+  "jti": "e9b7ef9d-f509-404a-8df5-e72d9f24e050",
+  "keyauth": "J65uIAsUjdJvNF0Frf7lyPlO7hlDGnWh.6AywWmNTDyCxWG7YJAz3kRxeceA-t2XnmT0twAJJbj0",
+  "name": "Alice Smith",
+  "nonce": "9yPAxE6EiPliwDJd3LZSPA",
+  "preferred_username": "wireapp://%40alice_wire@wire.com",
+  "session_state": "6dfbe005-854c-49cf-a2ec-8c7de826e00b",
+  "sid": "6dfbe005-854c-49cf-a2ec-8c7de826e00b",
+  "sub": "d4dec425-1436-4575-8db1-202cf9bf0304",
+  "typ": "ID"
+}
+```
+
+
+❌ Invalid Signature with key:
+```text
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1S175FnO1SBTJ0kjjGKn
+J6gzdOZw10u5VgugG7lwreyTbVAni8rDne2puFX+22kwTlu1GqhuMxMRTOo9iTI/
+yplRIRQbR5jTmCpfT7x5f79cn6AQeX5uBEfvSFLHVude8NSJbGInWJpGzF2tJ8KZ
+w3ZphwAUjhFEqLBAk1fkxW4t5oY3+o7wUnYDJJNAmNGZgJUqkXLWL/hkGdIDHyaq
+DivmLawRJA6oJPKzH45KbZ4c3KGv0mC++dgTU4qWr7Qvf0r4Drsu7jCQno1KXhon
+fWhuHt1RQKws8vtmbKVUOoXxoXyJpVp5koVTj/tCCafLfdhi4weODpk73Jkcd5Ci
+3QIDAQAB
 -----END PUBLIC KEY-----
 ```
 
@@ -593,64 +780,63 @@ ywIDAQAB
 
 Note: The ACME provisioner is configured with rules for transforming values received in the token into a Wire handle and display name.
 ```http request
-POST https://stepca:32795/acme/wire/challenge/RO1lN0FiYIud1rZZ6E3uiY5eRdnjVE0o/nRHOLoqoWZHI6CGGORPT3ibdevmdUEz4
+POST https://stepca:32900/acme/wire/challenge/PQMMQsFRGJ63rw5BJXcZRW5gdxiAnfza/2G5CjoDyCVob9Nf6lhT1hwRSNcjflZML
                          /acme/{acme-provisioner}/challenge/{authz-id}/{challenge-id}
 content-type: application/jose+json
 ```
 ```json
 {
-  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMyNzk1L2FjbWUvd2lyZS9hY2NvdW50L1o5cGNJNmlNVHpBMVRFTHUxSU5zbEZ4NkV0aFJlb1ZFIiwidHlwIjoiSldUIiwibm9uY2UiOiJjemRETkVKWFdXb3lOWGRpVWxkcVZVTlhkbmcwWVRWRE5sSjBlVzUyU2xvIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI3OTUvYWNtZS93aXJlL2NoYWxsZW5nZS9STzFsTjBGaVlJdWQxclpaNkUzdWlZNWVSZG5qVkUwby9uUkhPTG9xb1daSEk2Q0dHT1JQVDNpYmRldm1kVUV6NCJ9",
-  "payload": "eyJpZF90b2tlbiI6ImV5SmhiR2NpT2lKU1V6STFOaUlzSW10cFpDSTZJamM1Tm1Ka09URmtNR1V3TVdZMk5tTmpNRFF5TTJaalpHUmpZakV6WlRJelpqSXhOVEptTURNaWZRLmV5SnBjM01pT2lKb2RIUndPaTh2WkdWNE9qSXhNVEkyTDJSbGVDSXNJbk4xWWlJNklrTnFjRE5oV0Vwc1dWaENkMDlwT0haVFZrbDNXREJzVG1SRlRsVlVSMnQ2V1ZoTk1WSlhPVVJSYm1SWldubEdhazR5VW10WmJVWnBUVmRGTVUxcVNURmFSMVY0VVVoa2NHTnRWWFZaTWpsMFJXZFNjMXBIUm5jaUxDSmhkV1FpT2lKM2FYSmxZWEJ3SWl3aVpYaHdJam94TnpBMU5ESXlORFE1TENKcFlYUWlPakUzTURVek16WXdORGtzSW01dmJtTmxJam9pY1ZCdlJFRkhiWEZ4UVhOdVpGQjJVVTVTVjNKQ2R5SXNJbUYwWDJoaGMyZ2lPaUl3V21OdWNEVnlXVE41WkRKVlUxWnpiSFY0VFRWbklpd2lZMTlvWVhOb0lqb2laVVZHTjNSS05tWTBkbVZ6T0dsWWFYYzNSVlZ3WnlJc0ltNWhiV1VpT2lKM2FYSmxZWEJ3T2k4dkpUUXdZV3hwWTJWZmQybHlaVUIzYVhKbExtTnZiU0lzSW5CeVpXWmxjbkpsWkY5MWMyVnlibUZ0WlNJNklrRnNhV05sSUZOdGFYUm9JbjAuRDBUQkpDLWFSOWhfS3Z5R3paYlJMOUZNZk8za19BNVN4N3ZfdVlQd0lRekE4SDctWHAwVUtVaURTR0NoZGl1a3BveXYwT0lZVEdwbjk5Yi04TnU3NTZycXVaci1EcDB3NUxlV2dyUTRJN1BUT3ZveGhjdllkNnlOcExJVWZnTnFwQ0Y3U2REcHBMVGRwWnBNeXptb0VTdXo5cUxnUVFhYXM1UzQ0bzc2N2xzMkxfcW44eG1fRlNUMUcwdGJuNlV1ZmRadENpSTJqb2c3NUE3SktBSGZLcXB2NGVjbW9DRXJ6XzdMWGk5YnRCZVhtZUJXdjY5c2pzdzFzT2RVTmdMX21FSmVaSFo3NUw3S2pNWnUyTmlUVkR0VUZOczB2eDFveWZLdjB4d040MExfSWdtOG85aVNfR1ROWEx6SzlIYjNZdzRpdmQ5TkJzcDlGUFJTcjctckd3Iiwia2V5YXV0aCI6IjI1eENqWmwwd2d2MWpDVTRJdTZIZHRvc0I2eVl2dVNjLlNTeG1NUElqeFpYLWVEeEFrUmt4OGNYSmhETVdSVEdMaEY1dXlWZWpQNG8ifQ",
-  "signature": "1yUgZxNcZlM2PggKOn0Dg0_xxpQ7GBopLUbYJzZg7FzovVbdaY3ffYU0RnBsTUk6zq6XMbTiYx4PaqP8DSG-Aw"
+  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMyOTAwL2FjbWUvd2lyZS9hY2NvdW50L2dOTlI1Y0x0N1Q4MWR0QzJ6emVoRXZRS3U0TEFZQnl6IiwidHlwIjoiSldUIiwibm9uY2UiOiJXVWhYWjFoM2JGRk1SMFZuWVVaTWVuZE5hMlZTVDIwelVVRnZUak5MYVd3IiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI5MDAvYWNtZS93aXJlL2NoYWxsZW5nZS9QUU1NUXNGUkdKNjNydzVCSlhjWlJXNWdkeGlBbmZ6YS8yRzVDam9EeUNWb2I5TmY2bGhUMWh3UlNOY2pmbFpNTCJ9",
+  "payload": "eyJpZF90b2tlbiI6ImV5SmhiR2NpT2lKU1V6STFOaUlzSW5SNWNDSWdPaUFpU2xkVUlpd2lhMmxrSWlBNklDSmFlVEJKVkhGMllqSnpWVVZwZEZsTFVrazJObk51UXpoMWJFOVJWM00xWlVwcVRqSlBTSGxJZWxkTkluMC5leUpsZUhBaU9qRTNNRFUwTVRjNE1qQXNJbWxoZENJNk1UY3dOVFF4TnpjMk1Dd2lZWFYwYUY5MGFXMWxJam94TnpBMU5ERTNOell3TENKcWRHa2lPaUpsT1dJM1pXWTVaQzFtTlRBNUxUUXdOR0V0T0dSbU5TMWxOekprT1dZeU5HVXdOVEFpTENKcGMzTWlPaUpvZEhSd09pOHZhMlY1WTJ4dllXczZNak0yTnpVdmNtVmhiRzF6TDIxaGMzUmxjaUlzSW1GMVpDSTZJbmRwY21WaGNIQWlMQ0p6ZFdJaU9pSmtOR1JsWXpReU5TMHhORE0yTFRRMU56VXRPR1JpTVMweU1ESmpaamxpWmpBek1EUWlMQ0owZVhBaU9pSkpSQ0lzSW1GNmNDSTZJbmRwY21WaGNIQWlMQ0p1YjI1alpTSTZJamw1VUVGNFJUWkZhVkJzYVhkRVNtUXpURnBUVUVFaUxDSnpaWE56YVc5dVgzTjBZWFJsSWpvaU5tUm1ZbVV3TURVdE9EVTBZeTAwT1dObUxXRXlaV010T0dNM1pHVTRNalpsTURCaUlpd2lZWFJmYUdGemFDSTZJbGxvWVZoV1pXaEdRME5MYUZKNlQwdDFha2RUT0ZFaUxDSmhZM0lpT2lJeElpd2ljMmxrSWpvaU5tUm1ZbVV3TURVdE9EVTBZeTAwT1dObUxXRXlaV010T0dNM1pHVTRNalpsTURCaUlpd2laVzFoYVd4ZmRtVnlhV1pwWldRaU9uUnlkV1VzSW01aGJXVWlPaUpCYkdsalpTQlRiV2wwYUNJc0luQnlaV1psY25KbFpGOTFjMlZ5Ym1GdFpTSTZJbmRwY21WaGNIQTZMeThsTkRCaGJHbGpaVjkzYVhKbFFIZHBjbVV1WTI5dElpd2lhMlY1WVhWMGFDSTZJa28yTlhWSlFYTlZhbVJLZGs1R01FWnlaamRzZVZCc1R6ZG9iRVJIYmxkb0xqWkJlWGRYYlU1VVJIbERlRmRITjFsS1FYb3phMUo0WldObFFTMTBNbGh1YlZRd2RIZEJTa3BpYWpBaUxDSm5hWFpsYmw5dVlXMWxJam9pUVd4cFkyVWlMQ0ptWVcxcGJIbGZibUZ0WlNJNklsTnRhWFJvSWl3aVpXMWhhV3dpT2lKaGJHbGpaWE50YVhSb1FIZHBjbVV1WTI5dEluMC5qRmx4OHNHWEZkTHlRYXh0MDNKYUFxS3I5RTAzYkJ0azhqaGl5SkttOXlRMTRBOUJPT0FTbTdFY1NrVHRYM0RFblVuel9CSHpNX1FncTBQSEJpU2JQQXhRck83T0hGdThVQ2VacWVfdFRxLWI1VXBEUHlFSnZheFZNV09Uenk1ckI3c0RUdUxCZ3JCVzQxZDJTbUNxd05oaGcwcjBpYjZwOHFmU3hoTTFuTlpweGlsV0k3Yl9MWnliV21BaGRXS3E2eWZKZUdfeUdqMVV1WGtoMk03OXZQNGh1ZUZKOEx6bmZDRjVkVXNEVnNhekxsR3dTYWNNdjFLdTVoZ1pKekRrSTlCR0s0emJGMGd3aVBWdGQ3S1dHd2hEX0NVcEo3SHZCdmFwWVN3cWliYkZmLUFjRk9TampkRzZiSF9hQkFSYTBrQUMzWkh0T1hPUmpyZGRrQ1k0MVEifQ",
+  "signature": "CsGN1jheeaON0YaFVbq-FuyKIUrxuPEgdDbgrAgJW5ikYHLZSI7cLQxdfLLOEZOGaDRALERrsguywxW9BL_DBQ"
 }
 ```
 ```json
 {
   "payload": {
-    "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6Ijc5NmJkOTFkMGUwMWY2NmNjMDQyM2ZjZGRjYjEzZTIzZjIxNTJmMDMifQ.eyJpc3MiOiJodHRwOi8vZGV4OjIxMTI2L2RleCIsInN1YiI6IkNqcDNhWEpsWVhCd09pOHZTVkl3WDBsTmRFTlVUR2t6WVhNMVJXOURRbmRZWnlGak4yUmtZbUZpTVdFMU1qSTFaR1V4UUhkcGNtVXVZMjl0RWdSc1pHRnciLCJhdWQiOiJ3aXJlYXBwIiwiZXhwIjoxNzA1NDIyNDQ5LCJpYXQiOjE3MDUzMzYwNDksIm5vbmNlIjoicVBvREFHbXFxQXNuZFB2UU5SV3JCdyIsImF0X2hhc2giOiIwWmNucDVyWTN5ZDJVU1ZzbHV4TTVnIiwiY19oYXNoIjoiZUVGN3RKNmY0dmVzOGlYaXc3RVVwZyIsIm5hbWUiOiJ3aXJlYXBwOi8vJTQwYWxpY2Vfd2lyZUB3aXJlLmNvbSIsInByZWZlcnJlZF91c2VybmFtZSI6IkFsaWNlIFNtaXRoIn0.D0TBJC-aR9h_KvyGzZbRL9FMfO3k_A5Sx7v_uYPwIQzA8H7-Xp0UKUiDSGChdiukpoyv0OIYTGpn99b-8Nu756rquZr-Dp0w5LeWgrQ4I7PTOvoxhcvYd6yNpLIUfgNqpCF7SdDppLTdpZpMyzmoESuz9qLgQQaas5S44o767ls2L_qn8xm_FST1G0tbn6UufdZtCiI2jog75A7JKAHfKqpv4ecmoCErz_7LXi9btBeXmeBWv69sjsw1sOdUNgL_mEJeZHZ75L7KjMZu2NiTVDtUFNs0vx1oyfKv0xwN40L_Igm8o9iS_GTNXLzK9Hb3Yw4ivd9NBsp9FPRSr7-rGw",
-    "keyauth": "25xCjZl0wgv1jCU4Iu6HdtosB6yYvuSc.SSxmMPIjxZX-eDxAkRkx8cXJhDMWRTGLhF5uyVejP4o"
+    "id_token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJaeTBJVHF2YjJzVUVpdFlLUkk2NnNuQzh1bE9RV3M1ZUpqTjJPSHlIeldNIn0.eyJleHAiOjE3MDU0MTc4MjAsImlhdCI6MTcwNTQxNzc2MCwiYXV0aF90aW1lIjoxNzA1NDE3NzYwLCJqdGkiOiJlOWI3ZWY5ZC1mNTA5LTQwNGEtOGRmNS1lNzJkOWYyNGUwNTAiLCJpc3MiOiJodHRwOi8va2V5Y2xvYWs6MjM2NzUvcmVhbG1zL21hc3RlciIsImF1ZCI6IndpcmVhcHAiLCJzdWIiOiJkNGRlYzQyNS0xNDM2LTQ1NzUtOGRiMS0yMDJjZjliZjAzMDQiLCJ0eXAiOiJJRCIsImF6cCI6IndpcmVhcHAiLCJub25jZSI6Ijl5UEF4RTZFaVBsaXdESmQzTFpTUEEiLCJzZXNzaW9uX3N0YXRlIjoiNmRmYmUwMDUtODU0Yy00OWNmLWEyZWMtOGM3ZGU4MjZlMDBiIiwiYXRfaGFzaCI6IlloYVhWZWhGQ0NLaFJ6T0t1akdTOFEiLCJhY3IiOiIxIiwic2lkIjoiNmRmYmUwMDUtODU0Yy00OWNmLWEyZWMtOGM3ZGU4MjZlMDBiIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsIm5hbWUiOiJBbGljZSBTbWl0aCIsInByZWZlcnJlZF91c2VybmFtZSI6IndpcmVhcHA6Ly8lNDBhbGljZV93aXJlQHdpcmUuY29tIiwia2V5YXV0aCI6Iko2NXVJQXNVamRKdk5GMEZyZjdseVBsTzdobERHbldoLjZBeXdXbU5URHlDeFdHN1lKQXoza1J4ZWNlQS10MlhubVQwdHdBSkpiajAiLCJnaXZlbl9uYW1lIjoiQWxpY2UiLCJmYW1pbHlfbmFtZSI6IlNtaXRoIiwiZW1haWwiOiJhbGljZXNtaXRoQHdpcmUuY29tIn0.jFlx8sGXFdLyQaxt03JaAqKr9E03bBtk8jhiyJKm9yQ14A9BOOASm7EcSkTtX3DEnUnz_BHzM_Qgq0PHBiSbPAxQrO7OHFu8UCeZqe_tTq-b5UpDPyEJvaxVMWOTzy5rB7sDTuLBgrBW41d2SmCqwNhhg0r0ib6p8qfSxhM1nNZpxilWI7b_LZybWmAhdWKq6yfJeG_yGj1UuXkh2M79vP4hueFJ8LznfCF5dUsDVsazLlGwSacMv1Ku5hgZJzDkI9BGK4zbF0gwiPVtd7KWGwhD_CUpJ7HvBvapYSwqibbFf-AcFOSjjdG6bH_aBARa0kAC3ZHtOXORjrddkCY41Q"
   },
   "protected": {
     "alg": "EdDSA",
-    "kid": "https://stepca:32795/acme/wire/account/Z9pcI6iMTzA1TELu1INslFx6EthReoVE",
-    "nonce": "czdDNEJXWWoyNXdiUldqVUNXdng0YTVDNlJ0eW52Slo",
+    "kid": "https://stepca:32900/acme/wire/account/gNNR5cLt7T81dtC2zzehEvQKu4LAYByz",
+    "nonce": "WUhXZ1h3bFFMR0VnYUZMendNa2VST20zUUFvTjNLaWw",
     "typ": "JWT",
-    "url": "https://stepca:32795/acme/wire/challenge/RO1lN0FiYIud1rZZ6E3uiY5eRdnjVE0o/nRHOLoqoWZHI6CGGORPT3ibdevmdUEz4"
+    "url": "https://stepca:32900/acme/wire/challenge/PQMMQsFRGJ63rw5BJXcZRW5gdxiAnfza/2G5CjoDyCVob9Nf6lhT1hwRSNcjflZML"
   }
 }
 ```
-#### 25. OIDC challenge is valid
+#### 23. OIDC challenge is valid
 ```http request
 200
 cache-control: no-store
 content-type: application/json
-link: <https://stepca:32795/acme/wire/directory>;rel="index"
-link: <https://stepca:32795/acme/wire/authz/RO1lN0FiYIud1rZZ6E3uiY5eRdnjVE0o>;rel="up"
-location: https://stepca:32795/acme/wire/challenge/RO1lN0FiYIud1rZZ6E3uiY5eRdnjVE0o/nRHOLoqoWZHI6CGGORPT3ibdevmdUEz4
-replay-nonce: RXlibmZJRkhkNjVvMnROVkpEOXFqNkJrdjN2cmV1RGM
+link: <https://stepca:32900/acme/wire/directory>;rel="index"
+link: <https://stepca:32900/acme/wire/authz/PQMMQsFRGJ63rw5BJXcZRW5gdxiAnfza>;rel="up"
+location: https://stepca:32900/acme/wire/challenge/PQMMQsFRGJ63rw5BJXcZRW5gdxiAnfza/2G5CjoDyCVob9Nf6lhT1hwRSNcjflZML
+replay-nonce: N1VvNGNpWjNiVnVzV0V2UjVKd2RRWWFIaG9nZTVOeVc
 vary: Origin
 ```
 ```json
 {
   "type": "wire-oidc-01",
-  "url": "https://stepca:32795/acme/wire/challenge/RO1lN0FiYIud1rZZ6E3uiY5eRdnjVE0o/nRHOLoqoWZHI6CGGORPT3ibdevmdUEz4",
+  "url": "https://stepca:32900/acme/wire/challenge/PQMMQsFRGJ63rw5BJXcZRW5gdxiAnfza/2G5CjoDyCVob9Nf6lhT1hwRSNcjflZML",
   "status": "valid",
-  "token": "25xCjZl0wgv1jCU4Iu6HdtosB6yYvuSc",
-  "target": "http://dex:21126/dex"
+  "token": "J65uIAsUjdJvNF0Frf7lyPlO7hlDGnWh",
+  "target": "http://keycloak:23675/realms/master"
 }
 ```
 ### Client presents a CSR and gets its certificate
-#### 26. verify the status of the order
+#### 24. verify the status of the order
 ```http request
-POST https://stepca:32795/acme/wire/order/aVU5mwC8z8tGZeRX1jmGtKGpl8CYKDrV
+POST https://stepca:32900/acme/wire/order/ThEcRXInIL8Z4W7f9S3pQDZ9QxaPISa2
                          /acme/{acme-provisioner}/order/{order-id}
 content-type: application/jose+json
 ```
 ```json
 {
-  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMyNzk1L2FjbWUvd2lyZS9hY2NvdW50L1o5cGNJNmlNVHpBMVRFTHUxSU5zbEZ4NkV0aFJlb1ZFIiwidHlwIjoiSldUIiwibm9uY2UiOiJSWGxpYm1aSlJraGtOalZ2TW5ST1ZrcEVPWEZxTmtKcmRqTjJjbVYxUkdNIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI3OTUvYWNtZS93aXJlL29yZGVyL2FWVTVtd0M4ejh0R1plUlgxam1HdEtHcGw4Q1lLRHJWIn0",
+  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMyOTAwL2FjbWUvd2lyZS9hY2NvdW50L2dOTlI1Y0x0N1Q4MWR0QzJ6emVoRXZRS3U0TEFZQnl6IiwidHlwIjoiSldUIiwibm9uY2UiOiJOMVZ2TkdOcFdqTmlWblZ6VjBWMlVqVktkMlJSV1dGSWFHOW5aVFZPZVZjIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI5MDAvYWNtZS93aXJlL29yZGVyL1RoRWNSWEluSUw4WjRXN2Y5UzNwUURaOVF4YVBJU2EyIn0",
   "payload": "",
-  "signature": "K3qlgB5bIKZKuqiWsJqcoXLmzFhS7JZXezPYGPEww2oIthTHey7zWYc4N4gcxzu7JyRdA1kskT_NnDvsc84GCg"
+  "signature": "MEFTWDB7Y427EhvzWeZD4KUwc-hKYSWW3q4NUmmojSdcX28oTlqTlBvhyarwb4JwZaJ_6ld4PKEOvq_b2J9-AA"
 }
 ```
 ```json
@@ -658,65 +844,65 @@ content-type: application/jose+json
   "payload": {},
   "protected": {
     "alg": "EdDSA",
-    "kid": "https://stepca:32795/acme/wire/account/Z9pcI6iMTzA1TELu1INslFx6EthReoVE",
-    "nonce": "RXlibmZJRkhkNjVvMnROVkpEOXFqNkJrdjN2cmV1RGM",
+    "kid": "https://stepca:32900/acme/wire/account/gNNR5cLt7T81dtC2zzehEvQKu4LAYByz",
+    "nonce": "N1VvNGNpWjNiVnVzV0V2UjVKd2RRWWFIaG9nZTVOeVc",
     "typ": "JWT",
-    "url": "https://stepca:32795/acme/wire/order/aVU5mwC8z8tGZeRX1jmGtKGpl8CYKDrV"
+    "url": "https://stepca:32900/acme/wire/order/ThEcRXInIL8Z4W7f9S3pQDZ9QxaPISa2"
   }
 }
 ```
-#### 27. loop (with exponential backoff) until order is ready
+#### 25. loop (with exponential backoff) until order is ready
 ```http request
 200
 cache-control: no-store
 content-type: application/json
-link: <https://stepca:32795/acme/wire/directory>;rel="index"
-location: https://stepca:32795/acme/wire/order/aVU5mwC8z8tGZeRX1jmGtKGpl8CYKDrV
-replay-nonce: UHV6bDdONER0Vm1PRlZGcDltWTYxeEpJVWVKSjZzVDg
+link: <https://stepca:32900/acme/wire/directory>;rel="index"
+location: https://stepca:32900/acme/wire/order/ThEcRXInIL8Z4W7f9S3pQDZ9QxaPISa2
+replay-nonce: MGhRWlJrektSbkFGN01Fc3VkQmE3Vk5vSEh5ejFRNnI
 vary: Origin
 ```
 ```json
 {
   "status": "ready",
-  "finalize": "https://stepca:32795/acme/wire/order/aVU5mwC8z8tGZeRX1jmGtKGpl8CYKDrV/finalize",
+  "finalize": "https://stepca:32900/acme/wire/order/ThEcRXInIL8Z4W7f9S3pQDZ9QxaPISa2/finalize",
   "identifiers": [
     {
       "type": "wireapp-id",
-      "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"wireapp://IR0_IMtCTLi3as5EoCBwXg!c7ddbab1a5225de1@wire.com\",\"handle\":\"wireapp://%40alice_wire@wire.com\"}"
+      "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"wireapp://qHiDLsbkT2-p9uSJsmrZ_A!7f39900830740008@wire.com\",\"handle\":\"wireapp://%40alice_wire@wire.com\"}"
     }
   ],
   "authorizations": [
-    "https://stepca:32795/acme/wire/authz/RO1lN0FiYIud1rZZ6E3uiY5eRdnjVE0o"
+    "https://stepca:32900/acme/wire/authz/PQMMQsFRGJ63rw5BJXcZRW5gdxiAnfza"
   ],
-  "expires": "2024-01-16T16:27:29Z",
-  "notBefore": "2024-01-15T16:27:29.233725Z",
-  "notAfter": "2034-01-12T16:27:29.233725Z"
+  "expires": "2024-01-17T15:09:20Z",
+  "notBefore": "2024-01-16T15:09:20.404389Z",
+  "notAfter": "2034-01-13T15:09:20.404389Z"
 }
 ```
-#### 28. create a CSR and call finalize url
+#### 26. create a CSR and call finalize url
 ```http request
-POST https://stepca:32795/acme/wire/order/aVU5mwC8z8tGZeRX1jmGtKGpl8CYKDrV/finalize
+POST https://stepca:32900/acme/wire/order/ThEcRXInIL8Z4W7f9S3pQDZ9QxaPISa2/finalize
                          /acme/{acme-provisioner}/order/{order-id}/finalize
 content-type: application/jose+json
 ```
 ```json
 {
-  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMyNzk1L2FjbWUvd2lyZS9hY2NvdW50L1o5cGNJNmlNVHpBMVRFTHUxSU5zbEZ4NkV0aFJlb1ZFIiwidHlwIjoiSldUIiwibm9uY2UiOiJVSFY2YkRkT05FUjBWbTFQUmxaR2NEbHRXVFl4ZUVwSlZXVktTalp6VkRnIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI3OTUvYWNtZS93aXJlL29yZGVyL2FWVTVtd0M4ejh0R1plUlgxam1HdEtHcGw4Q1lLRHJWL2ZpbmFsaXplIn0",
-  "payload": "eyJjc3IiOiJNSUlCS3pDQjNnSUJBREF4TVJFd0R3WURWUVFLREFoM2FYSmxMbU52YlRFY01Cb0dDMkNHU0FHRy1FSURBWUZ4REF0QmJHbGpaU0JUYldsMGFEQXFNQVVHQXl0bGNBTWhBTmFTZDlub0JrRVp0YjUwNU9ZOFpJdm5JbF9MSXhqanBZZDdPa2hHQUlOM29Ib3dlQVlKS29aSWh2Y05BUWtPTVdzd2FUQm5CZ05WSFJFRVlEQmVoanAzYVhKbFlYQndPaTh2U1ZJd1gwbE5kRU5VVEdrellYTTFSVzlEUW5kWVp5RmpOMlJrWW1GaU1XRTFNakkxWkdVeFFIZHBjbVV1WTI5dGhpQjNhWEpsWVhCd09pOHZKVFF3WVd4cFkyVmZkMmx5WlVCM2FYSmxMbU52YlRBRkJnTXJaWEFEUVFDQ2VxU21seDFtaFdXZnEwaWJIMlRYb2NWQ0RTbkdaY1lvSnEwZ2VZaDJHaVRoSzlsR05IVm82MGhxb210bXhtRWQtNE5mVnU5UXNEWHk4TEtRQTRBSyJ9",
-  "signature": "vx3uMwnyHc56idl_4RtrJCRQMqn1WKRZLIt53xZUipw3ErvsYyaR4M8lYuJieKL2Bc1GFYmVorVWizj7-8ntDQ"
+  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMyOTAwL2FjbWUvd2lyZS9hY2NvdW50L2dOTlI1Y0x0N1Q4MWR0QzJ6emVoRXZRS3U0TEFZQnl6IiwidHlwIjoiSldUIiwibm9uY2UiOiJNR2hSV2xKcmVrdFNia0ZHTjAxRmMzVmtRbUUzVms1dlNFaDVlakZSTm5JIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI5MDAvYWNtZS93aXJlL29yZGVyL1RoRWNSWEluSUw4WjRXN2Y5UzNwUURaOVF4YVBJU2EyL2ZpbmFsaXplIn0",
+  "payload": "eyJjc3IiOiJNSUlCS3pDQjNnSUJBREF4TVJFd0R3WURWUVFLREFoM2FYSmxMbU52YlRFY01Cb0dDMkNHU0FHRy1FSURBWUZ4REF0QmJHbGpaU0JUYldsMGFEQXFNQVVHQXl0bGNBTWhBT01LMzE5Ylh0dnB2b1Buc3ZxOGx6eU9WRkVLdU9Mak1PVVFIMkJkdi1xbW9Ib3dlQVlKS29aSWh2Y05BUWtPTVdzd2FUQm5CZ05WSFJFRVlEQmVoanAzYVhKbFlYQndPaTh2Y1VocFJFeHpZbXRVTWkxd09YVlRTbk50Y2xwZlFTRTNaak01T1RBd09ETXdOelF3TURBNFFIZHBjbVV1WTI5dGhpQjNhWEpsWVhCd09pOHZKVFF3WVd4cFkyVmZkMmx5WlVCM2FYSmxMbU52YlRBRkJnTXJaWEFEUVFEcEVKTF82Uk9xN2NrelFvcDF6QlBiNjBIcDFlUEo1WmxMQTZuQUt0OGstZldjcVgxVUdlNlpHU3pQbVl1ekYwbGQxd3JrMWEyR0Zwd18wRC1tMmx3QyJ9",
+  "signature": "rCNvbyaakt-WFuHTXLRqmg75iZYPDKRPzfx2R0Kk6XUIvyQP8pYt8dYc1KMXUNSCEl5g14ZyZyipd3AoQDo9DQ"
 }
 ```
 ```json
 {
   "payload": {
-    "csr": "MIIBKzCB3gIBADAxMREwDwYDVQQKDAh3aXJlLmNvbTEcMBoGC2CGSAGG-EIDAYFxDAtBbGljZSBTbWl0aDAqMAUGAytlcAMhANaSd9noBkEZtb505OY8ZIvnIl_LIxjjpYd7OkhGAIN3oHoweAYJKoZIhvcNAQkOMWswaTBnBgNVHREEYDBehjp3aXJlYXBwOi8vSVIwX0lNdENUTGkzYXM1RW9DQndYZyFjN2RkYmFiMWE1MjI1ZGUxQHdpcmUuY29thiB3aXJlYXBwOi8vJTQwYWxpY2Vfd2lyZUB3aXJlLmNvbTAFBgMrZXADQQCCeqSmlx1mhWWfq0ibH2TXocVCDSnGZcYoJq0geYh2GiThK9lGNHVo60hqomtmxmEd-4NfVu9QsDXy8LKQA4AK"
+    "csr": "MIIBKzCB3gIBADAxMREwDwYDVQQKDAh3aXJlLmNvbTEcMBoGC2CGSAGG-EIDAYFxDAtBbGljZSBTbWl0aDAqMAUGAytlcAMhAOMK319bXtvpvoPnsvq8lzyOVFEKuOLjMOUQH2Bdv-qmoHoweAYJKoZIhvcNAQkOMWswaTBnBgNVHREEYDBehjp3aXJlYXBwOi8vcUhpRExzYmtUMi1wOXVTSnNtclpfQSE3ZjM5OTAwODMwNzQwMDA4QHdpcmUuY29thiB3aXJlYXBwOi8vJTQwYWxpY2Vfd2lyZUB3aXJlLmNvbTAFBgMrZXADQQDpEJL_6ROq7ckzQop1zBPb60Hp1ePJ5ZlLA6nAKt8k-fWcqX1UGe6ZGSzPmYuzF0ld1wrk1a2GFpw_0D-m2lwC"
   },
   "protected": {
     "alg": "EdDSA",
-    "kid": "https://stepca:32795/acme/wire/account/Z9pcI6iMTzA1TELu1INslFx6EthReoVE",
-    "nonce": "UHV6bDdONER0Vm1PRlZGcDltWTYxeEpJVWVKSjZzVDg",
+    "kid": "https://stepca:32900/acme/wire/account/gNNR5cLt7T81dtC2zzehEvQKu4LAYByz",
+    "nonce": "MGhRWlJrektSbkFGN01Fc3VkQmE3Vk5vSEh5ejFRNnI",
     "typ": "JWT",
-    "url": "https://stepca:32795/acme/wire/order/aVU5mwC8z8tGZeRX1jmGtKGpl8CYKDrV/finalize"
+    "url": "https://stepca:32900/acme/wire/order/ThEcRXInIL8Z4W7f9S3pQDZ9QxaPISa2/finalize"
   }
 }
 ```
@@ -725,12 +911,12 @@ openssl -verify ✅
 ```
 -----BEGIN CERTIFICATE REQUEST-----
 MIIBKzCB3gIBADAxMREwDwYDVQQKDAh3aXJlLmNvbTEcMBoGC2CGSAGG+EIDAYFx
-DAtBbGljZSBTbWl0aDAqMAUGAytlcAMhANaSd9noBkEZtb505OY8ZIvnIl/LIxjj
-pYd7OkhGAIN3oHoweAYJKoZIhvcNAQkOMWswaTBnBgNVHREEYDBehjp3aXJlYXBw
-Oi8vSVIwX0lNdENUTGkzYXM1RW9DQndYZyFjN2RkYmFiMWE1MjI1ZGUxQHdpcmUu
-Y29thiB3aXJlYXBwOi8vJTQwYWxpY2Vfd2lyZUB3aXJlLmNvbTAFBgMrZXADQQCC
-eqSmlx1mhWWfq0ibH2TXocVCDSnGZcYoJq0geYh2GiThK9lGNHVo60hqomtmxmEd
-+4NfVu9QsDXy8LKQA4AK
+DAtBbGljZSBTbWl0aDAqMAUGAytlcAMhAOMK319bXtvpvoPnsvq8lzyOVFEKuOLj
+MOUQH2Bdv+qmoHoweAYJKoZIhvcNAQkOMWswaTBnBgNVHREEYDBehjp3aXJlYXBw
+Oi8vcUhpRExzYmtUMi1wOXVTSnNtclpfQSE3ZjM5OTAwODMwNzQwMDA4QHdpcmUu
+Y29thiB3aXJlYXBwOi8vJTQwYWxpY2Vfd2lyZUB3aXJlLmNvbTAFBgMrZXADQQDp
+EJL/6ROq7ckzQop1zBPb60Hp1ePJ5ZlLA6nAKt8k+fWcqX1UGe6ZGSzPmYuzF0ld
+1wrk1a2GFpw/0D+m2lwC
 -----END CERTIFICATE REQUEST-----
 
 ```
@@ -743,62 +929,62 @@ Certificate Request:
             Public Key Algorithm: ED25519
                 ED25519 Public-Key:
                 pub:
-                    d6:92:77:d9:e8:06:41:19:b5:be:74:e4:e6:3c:64:
-                    8b:e7:22:5f:cb:23:18:e3:a5:87:7b:3a:48:46:00:
-                    83:77
+                    e3:0a:df:5f:5b:5e:db:e9:be:83:e7:b2:fa:bc:97:
+                    3c:8e:54:51:0a:b8:e2:e3:30:e5:10:1f:60:5d:bf:
+                    ea:a6
         Attributes:
             Requested Extensions:
                 X509v3 Subject Alternative Name: 
-                    URI:wireapp://IR0_IMtCTLi3as5EoCBwXg!c7ddbab1a5225de1@wire.com, URI:wireapp://%40alice_wire@wire.com
+                    URI:wireapp://qHiDLsbkT2-p9uSJsmrZ_A!7f39900830740008@wire.com, URI:wireapp://%40alice_wire@wire.com
     Signature Algorithm: ED25519
     Signature Value:
-        82:7a:a4:a6:97:1d:66:85:65:9f:ab:48:9b:1f:64:d7:a1:c5:
-        42:0d:29:c6:65:c6:28:26:ad:20:79:88:76:1a:24:e1:2b:d9:
-        46:34:75:68:eb:48:6a:a2:6b:66:c6:61:1d:fb:83:5f:56:ef:
-        50:b0:35:f2:f0:b2:90:03:80:0a
+        e9:10:92:ff:e9:13:aa:ed:c9:33:42:8a:75:cc:13:db:eb:41:
+        e9:d5:e3:c9:e5:99:4b:03:a9:c0:2a:df:24:f9:f5:9c:a9:7d:
+        54:19:ee:99:19:2c:cf:99:8b:b3:17:49:5d:d7:0a:e4:d5:ad:
+        86:16:9c:3f:d0:3f:a6:da:5c:02
 
 ```
 
-#### 29. get back a url for fetching the certificate
+#### 27. get back a url for fetching the certificate
 ```http request
 200
 cache-control: no-store
 content-type: application/json
-link: <https://stepca:32795/acme/wire/directory>;rel="index"
-location: https://stepca:32795/acme/wire/order/aVU5mwC8z8tGZeRX1jmGtKGpl8CYKDrV
-replay-nonce: NmNKSTRqOFJOODF5SjhSeWxIdUF2czFKSDVDUXZCUVY
+link: <https://stepca:32900/acme/wire/directory>;rel="index"
+location: https://stepca:32900/acme/wire/order/ThEcRXInIL8Z4W7f9S3pQDZ9QxaPISa2
+replay-nonce: a1Y2M2xDaEx2QkJHcGkySkl1TGxoemhvSndtaThQYkE
 vary: Origin
 ```
 ```json
 {
-  "certificate": "https://stepca:32795/acme/wire/certificate/iRBWw7qQq4v0vzo9sBGWya6v31jD5mRL",
+  "certificate": "https://stepca:32900/acme/wire/certificate/eN4Q9SLomOjJnA5YMDXNOHz7uRpMpg2t",
   "status": "valid",
-  "finalize": "https://stepca:32795/acme/wire/order/aVU5mwC8z8tGZeRX1jmGtKGpl8CYKDrV/finalize",
+  "finalize": "https://stepca:32900/acme/wire/order/ThEcRXInIL8Z4W7f9S3pQDZ9QxaPISa2/finalize",
   "identifiers": [
     {
       "type": "wireapp-id",
-      "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"wireapp://IR0_IMtCTLi3as5EoCBwXg!c7ddbab1a5225de1@wire.com\",\"handle\":\"wireapp://%40alice_wire@wire.com\"}"
+      "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"wireapp://qHiDLsbkT2-p9uSJsmrZ_A!7f39900830740008@wire.com\",\"handle\":\"wireapp://%40alice_wire@wire.com\"}"
     }
   ],
   "authorizations": [
-    "https://stepca:32795/acme/wire/authz/RO1lN0FiYIud1rZZ6E3uiY5eRdnjVE0o"
+    "https://stepca:32900/acme/wire/authz/PQMMQsFRGJ63rw5BJXcZRW5gdxiAnfza"
   ],
-  "expires": "2024-01-16T16:27:29Z",
-  "notBefore": "2024-01-15T16:27:29.233725Z",
-  "notAfter": "2034-01-12T16:27:29.233725Z"
+  "expires": "2024-01-17T15:09:20Z",
+  "notBefore": "2024-01-16T15:09:20.404389Z",
+  "notAfter": "2034-01-13T15:09:20.404389Z"
 }
 ```
-#### 30. fetch the certificate
+#### 28. fetch the certificate
 ```http request
-POST https://stepca:32795/acme/wire/certificate/iRBWw7qQq4v0vzo9sBGWya6v31jD5mRL
+POST https://stepca:32900/acme/wire/certificate/eN4Q9SLomOjJnA5YMDXNOHz7uRpMpg2t
                          /acme/{acme-provisioner}/certificate/{certificate-id}
 content-type: application/jose+json
 ```
 ```json
 {
-  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMyNzk1L2FjbWUvd2lyZS9hY2NvdW50L1o5cGNJNmlNVHpBMVRFTHUxSU5zbEZ4NkV0aFJlb1ZFIiwidHlwIjoiSldUIiwibm9uY2UiOiJObU5LU1RScU9GSk9PREY1U2poU2VXeElkVUYyY3pGS1NEVkRVWFpDVVZZIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI3OTUvYWNtZS93aXJlL2NlcnRpZmljYXRlL2lSQld3N3FRcTR2MHZ6bzlzQkdXeWE2djMxakQ1bVJMIn0",
+  "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6Imh0dHBzOi8vc3RlcGNhOjMyOTAwL2FjbWUvd2lyZS9hY2NvdW50L2dOTlI1Y0x0N1Q4MWR0QzJ6emVoRXZRS3U0TEFZQnl6IiwidHlwIjoiSldUIiwibm9uY2UiOiJhMVkyTTJ4RGFFeDJRa0pIY0dreVNrbDFUR3hvZW1odlNuZHRhVGhRWWtFIiwidXJsIjoiaHR0cHM6Ly9zdGVwY2E6MzI5MDAvYWNtZS93aXJlL2NlcnRpZmljYXRlL2VONFE5U0xvbU9qSm5BNVlNRFhOT0h6N3VScE1wZzJ0In0",
   "payload": "",
-  "signature": "GcvUbPuI6Yu_A_xvaN1AfFxgnwHXmUO5UElKiM45VmaraVvJR6jip47beZRDjm7G53nrnfa97zjSSrUW2_qQDA"
+  "signature": "tD-46v0qiPxA_yytr8kSYkHIkIbM25TVmDl_UUyASf3sXy65cWksSAX4F2eigjuFvojaNGCTnsfMYkVClyTLBg"
 }
 ```
 ```json
@@ -806,41 +992,41 @@ content-type: application/jose+json
   "payload": {},
   "protected": {
     "alg": "EdDSA",
-    "kid": "https://stepca:32795/acme/wire/account/Z9pcI6iMTzA1TELu1INslFx6EthReoVE",
-    "nonce": "NmNKSTRqOFJOODF5SjhSeWxIdUF2czFKSDVDUXZCUVY",
+    "kid": "https://stepca:32900/acme/wire/account/gNNR5cLt7T81dtC2zzehEvQKu4LAYByz",
+    "nonce": "a1Y2M2xDaEx2QkJHcGkySkl1TGxoemhvSndtaThQYkE",
     "typ": "JWT",
-    "url": "https://stepca:32795/acme/wire/certificate/iRBWw7qQq4v0vzo9sBGWya6v31jD5mRL"
+    "url": "https://stepca:32900/acme/wire/certificate/eN4Q9SLomOjJnA5YMDXNOHz7uRpMpg2t"
   }
 }
 ```
-#### 31. get the certificate chain
+#### 29. get the certificate chain
 ```http request
 200
 cache-control: no-store
 content-type: application/pem-certificate-chain
-link: <https://stepca:32795/acme/wire/directory>;rel="index"
-replay-nonce: dERlM0RCeHB2ZG1wY3BLeWl2QnlhWk15OUJkd2FqZ0I
+link: <https://stepca:32900/acme/wire/directory>;rel="index"
+replay-nonce: U2gwSDNXSkkwSGd0TUN3bG94QWllY1UxbTRXdnJ2VHI
 vary: Origin
 ```
 ```json
-"-----BEGIN CERTIFICATE-----\nMIICGDCCAb+gAwIBAgIQFKrxUIOl/+stA8ohkT7CRTAKBggqhkjOPQQDAjAuMQ0w\nCwYDVQQKEwR3aXJlMR0wGwYDVQQDExR3aXJlIEludGVybWVkaWF0ZSBDQTAeFw0y\nNDAxMTUxNjI3MjlaFw0zNDAxMTIxNjI3MjlaMCkxETAPBgNVBAoTCHdpcmUuY29t\nMRQwEgYDVQQDEwtBbGljZSBTbWl0aDAqMAUGAytlcAMhANaSd9noBkEZtb505OY8\nZIvnIl/LIxjjpYd7OkhGAIN3o4HyMIHvMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUE\nDDAKBggrBgEFBQcDAjAdBgNVHQ4EFgQUoywPSB9g4RQwxojHhvIMhZw6y4EwHwYD\nVR0jBBgwFoAUU5Ngeiq+vNIDcWmTNeO0LYpUjdIwaQYDVR0RBGIwYIYgd2lyZWFw\ncDovLyU0MGFsaWNlX3dpcmVAd2lyZS5jb22GPHdpcmVhcHA6Ly9JUjBfSU10Q1RM\naTNhczVFb0NCd1hnJTIxYzdkZGJhYjFhNTIyNWRlMUB3aXJlLmNvbTAdBgwrBgEE\nAYKkZMYoQAEEDTALAgEGBAR3aXJlBAAwCgYIKoZIzj0EAwIDRwAwRAIgcVSHg0wM\nbGvOROprW0uf/YDog4+V8WXOayfi/B9WHqACIH159dt2KejVU+d7DdeYm3AXlYma\n/iwmT4PqBh7RF41G\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIBuTCCAV+gAwIBAgIRANlfaayTw0MW4FeGIikyAF0wCgYIKoZIzj0EAwIwJjEN\nMAsGA1UEChMEd2lyZTEVMBMGA1UEAxMMd2lyZSBSb290IENBMB4XDTI0MDExNTE2\nMjcyN1oXDTM0MDExMjE2MjcyN1owLjENMAsGA1UEChMEd2lyZTEdMBsGA1UEAxMU\nd2lyZSBJbnRlcm1lZGlhdGUgQ0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASM\nrvbahGvChOOs5Eqs7qqdQvfXNT9IIkP78Hxm9fNRKk4hG7UHj5x1R0Ve6kEa7X5A\ncmFYV/U9oLuDn1ZOGHljo2YwZDAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgw\nBgEB/wIBADAdBgNVHQ4EFgQUU5Ngeiq+vNIDcWmTNeO0LYpUjdIwHwYDVR0jBBgw\nFoAUAc3VI5dPjzJMHbsakKImbSK26sowCgYIKoZIzj0EAwIDSAAwRQIgQeA2iFTD\nu/a46ccjZoVXtvicaXn+dUeYbxyS6PToeDICIQDBEmh6g6rlLANVHNbC5zC2wWsY\nmHvml2cv5JFGTSYdtQ==\n-----END CERTIFICATE-----\n"
+"-----BEGIN CERTIFICATE-----\nMIICGjCCAb+gAwIBAgIQPLhnaE6aYNLfbidzAp50yjAKBggqhkjOPQQDAjAuMQ0w\nCwYDVQQKEwR3aXJlMR0wGwYDVQQDExR3aXJlIEludGVybWVkaWF0ZSBDQTAeFw0y\nNDAxMTYxNTA5MjBaFw0zNDAxMTMxNTA5MjBaMCkxETAPBgNVBAoTCHdpcmUuY29t\nMRQwEgYDVQQDEwtBbGljZSBTbWl0aDAqMAUGAytlcAMhAOMK319bXtvpvoPnsvq8\nlzyOVFEKuOLjMOUQH2Bdv+qmo4HyMIHvMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUE\nDDAKBggrBgEFBQcDAjAdBgNVHQ4EFgQUEBZTO9TS3Y7InptUwzDx3cFfyJEwHwYD\nVR0jBBgwFoAUL5YqVyZXiMW5t/DGkuZdANPJ4HowaQYDVR0RBGIwYIYgd2lyZWFw\ncDovLyU0MGFsaWNlX3dpcmVAd2lyZS5jb22GPHdpcmVhcHA6Ly9xSGlETHNia1Qy\nLXA5dVNKc21yWl9BJTIxN2YzOTkwMDgzMDc0MDAwOEB3aXJlLmNvbTAdBgwrBgEE\nAYKkZMYoQAEEDTALAgEGBAR3aXJlBAAwCgYIKoZIzj0EAwIDSQAwRgIhANfc/l4I\n6v70iPKAfFs01Ldqf0h5iVGTU1/AlvzzJF45AiEAz7rtuMUud49592HTsEIAz5MZ\nogeEg/9of5E0/LJXRdY=\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIBuTCCAV+gAwIBAgIRAJy6V6Ss8fpxNeZQor0s0BYwCgYIKoZIzj0EAwIwJjEN\nMAsGA1UEChMEd2lyZTEVMBMGA1UEAxMMd2lyZSBSb290IENBMB4XDTI0MDExNjE1\nMDkxOFoXDTM0MDExMzE1MDkxOFowLjENMAsGA1UEChMEd2lyZTEdMBsGA1UEAxMU\nd2lyZSBJbnRlcm1lZGlhdGUgQ0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATJ\nIZgIKmrKQ9qqsvKsl+0frjdV+N+6LFx3FN0QVXDPFiQe4X2un88eeg79+fW3yXhi\nDHf196luRN3ydPvScAGgo2YwZDAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgw\nBgEB/wIBADAdBgNVHQ4EFgQUL5YqVyZXiMW5t/DGkuZdANPJ4HowHwYDVR0jBBgw\nFoAUfo7V/ISNlOldc1fr/SNvGrJcbV0wCgYIKoZIzj0EAwIDSAAwRQIgVeS/71Yn\noM/M5UOBVjGOZjWI/gjFUY/YJOv8mNwi9E0CIQCWyfsrXjHY3cutjYWdRhYhcxnF\nQdjSQ8JcFoE8bVhyog==\n-----END CERTIFICATE-----\n"
 ```
 ###### Certificate #1
 
 ```
 -----BEGIN CERTIFICATE-----
-MIICGDCCAb+gAwIBAgIQFKrxUIOl/+stA8ohkT7CRTAKBggqhkjOPQQDAjAuMQ0w
+MIICGjCCAb+gAwIBAgIQPLhnaE6aYNLfbidzAp50yjAKBggqhkjOPQQDAjAuMQ0w
 CwYDVQQKEwR3aXJlMR0wGwYDVQQDExR3aXJlIEludGVybWVkaWF0ZSBDQTAeFw0y
-NDAxMTUxNjI3MjlaFw0zNDAxMTIxNjI3MjlaMCkxETAPBgNVBAoTCHdpcmUuY29t
-MRQwEgYDVQQDEwtBbGljZSBTbWl0aDAqMAUGAytlcAMhANaSd9noBkEZtb505OY8
-ZIvnIl/LIxjjpYd7OkhGAIN3o4HyMIHvMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUE
-DDAKBggrBgEFBQcDAjAdBgNVHQ4EFgQUoywPSB9g4RQwxojHhvIMhZw6y4EwHwYD
-VR0jBBgwFoAUU5Ngeiq+vNIDcWmTNeO0LYpUjdIwaQYDVR0RBGIwYIYgd2lyZWFw
-cDovLyU0MGFsaWNlX3dpcmVAd2lyZS5jb22GPHdpcmVhcHA6Ly9JUjBfSU10Q1RM
-aTNhczVFb0NCd1hnJTIxYzdkZGJhYjFhNTIyNWRlMUB3aXJlLmNvbTAdBgwrBgEE
-AYKkZMYoQAEEDTALAgEGBAR3aXJlBAAwCgYIKoZIzj0EAwIDRwAwRAIgcVSHg0wM
-bGvOROprW0uf/YDog4+V8WXOayfi/B9WHqACIH159dt2KejVU+d7DdeYm3AXlYma
-/iwmT4PqBh7RF41G
+NDAxMTYxNTA5MjBaFw0zNDAxMTMxNTA5MjBaMCkxETAPBgNVBAoTCHdpcmUuY29t
+MRQwEgYDVQQDEwtBbGljZSBTbWl0aDAqMAUGAytlcAMhAOMK319bXtvpvoPnsvq8
+lzyOVFEKuOLjMOUQH2Bdv+qmo4HyMIHvMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUE
+DDAKBggrBgEFBQcDAjAdBgNVHQ4EFgQUEBZTO9TS3Y7InptUwzDx3cFfyJEwHwYD
+VR0jBBgwFoAUL5YqVyZXiMW5t/DGkuZdANPJ4HowaQYDVR0RBGIwYIYgd2lyZWFw
+cDovLyU0MGFsaWNlX3dpcmVAd2lyZS5jb22GPHdpcmVhcHA6Ly9xSGlETHNia1Qy
+LXA5dVNKc21yWl9BJTIxN2YzOTkwMDgzMDc0MDAwOEB3aXJlLmNvbTAdBgwrBgEE
+AYKkZMYoQAEEDTALAgEGBAR3aXJlBAAwCgYIKoZIzj0EAwIDSQAwRgIhANfc/l4I
+6v70iPKAfFs01Ldqf0h5iVGTU1/AlvzzJF45AiEAz7rtuMUud49592HTsEIAz5MZ
+ogeEg/9of5E0/LJXRdY=
 -----END CERTIFICATE-----
 
 ```
@@ -849,39 +1035,39 @@ Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number:
-            14:aa:f1:50:83:a5:ff:eb:2d:03:ca:21:91:3e:c2:45
+            3c:b8:67:68:4e:9a:60:d2:df:6e:27:73:02:9e:74:ca
         Signature Algorithm: ecdsa-with-SHA256
         Issuer: O=wire, CN=wire Intermediate CA
         Validity
-            Not Before: Jan 15 16:27:29 2024 GMT
-            Not After : Jan 12 16:27:29 2034 GMT
+            Not Before: Jan 16 15:09:20 2024 GMT
+            Not After : Jan 13 15:09:20 2034 GMT
         Subject: O=wire.com, CN=Alice Smith
         Subject Public Key Info:
             Public Key Algorithm: ED25519
                 ED25519 Public-Key:
                 pub:
-                    d6:92:77:d9:e8:06:41:19:b5:be:74:e4:e6:3c:64:
-                    8b:e7:22:5f:cb:23:18:e3:a5:87:7b:3a:48:46:00:
-                    83:77
+                    e3:0a:df:5f:5b:5e:db:e9:be:83:e7:b2:fa:bc:97:
+                    3c:8e:54:51:0a:b8:e2:e3:30:e5:10:1f:60:5d:bf:
+                    ea:a6
         X509v3 extensions:
             X509v3 Key Usage: critical
                 Digital Signature
             X509v3 Extended Key Usage: 
                 TLS Web Client Authentication
             X509v3 Subject Key Identifier: 
-                A3:2C:0F:48:1F:60:E1:14:30:C6:88:C7:86:F2:0C:85:9C:3A:CB:81
+                10:16:53:3B:D4:D2:DD:8E:C8:9E:9B:54:C3:30:F1:DD:C1:5F:C8:91
             X509v3 Authority Key Identifier: 
-                53:93:60:7A:2A:BE:BC:D2:03:71:69:93:35:E3:B4:2D:8A:54:8D:D2
+                2F:96:2A:57:26:57:88:C5:B9:B7:F0:C6:92:E6:5D:00:D3:C9:E0:7A
             X509v3 Subject Alternative Name: 
-                URI:wireapp://%40alice_wire@wire.com, URI:wireapp://IR0_IMtCTLi3as5EoCBwXg%21c7ddbab1a5225de1@wire.com
+                URI:wireapp://%40alice_wire@wire.com, URI:wireapp://qHiDLsbkT2-p9uSJsmrZ_A%217f39900830740008@wire.com
             1.3.6.1.4.1.37476.9000.64.1: 
                 0......wire..
     Signature Algorithm: ecdsa-with-SHA256
     Signature Value:
-        30:44:02:20:71:54:87:83:4c:0c:6c:6b:ce:44:ea:6b:5b:4b:
-        9f:fd:80:e8:83:8f:95:f1:65:ce:6b:27:e2:fc:1f:56:1e:a0:
-        02:20:7d:79:f5:db:76:29:e8:d5:53:e7:7b:0d:d7:98:9b:70:
-        17:95:89:9a:fe:2c:26:4f:83:ea:06:1e:d1:17:8d:46
+        30:46:02:21:00:d7:dc:fe:5e:08:ea:fe:f4:88:f2:80:7c:5b:
+        34:d4:b7:6a:7f:48:79:89:51:93:53:5f:c0:96:fc:f3:24:5e:
+        39:02:21:00:cf:ba:ed:b8:c5:2e:77:8f:79:f7:61:d3:b0:42:
+        00:cf:93:19:a2:07:84:83:ff:68:7f:91:34:fc:b2:57:45:d6
 
 ```
 
@@ -889,16 +1075,16 @@ Certificate:
 
 ```
 -----BEGIN CERTIFICATE-----
-MIIBuTCCAV+gAwIBAgIRANlfaayTw0MW4FeGIikyAF0wCgYIKoZIzj0EAwIwJjEN
-MAsGA1UEChMEd2lyZTEVMBMGA1UEAxMMd2lyZSBSb290IENBMB4XDTI0MDExNTE2
-MjcyN1oXDTM0MDExMjE2MjcyN1owLjENMAsGA1UEChMEd2lyZTEdMBsGA1UEAxMU
-d2lyZSBJbnRlcm1lZGlhdGUgQ0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASM
-rvbahGvChOOs5Eqs7qqdQvfXNT9IIkP78Hxm9fNRKk4hG7UHj5x1R0Ve6kEa7X5A
-cmFYV/U9oLuDn1ZOGHljo2YwZDAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgw
-BgEB/wIBADAdBgNVHQ4EFgQUU5Ngeiq+vNIDcWmTNeO0LYpUjdIwHwYDVR0jBBgw
-FoAUAc3VI5dPjzJMHbsakKImbSK26sowCgYIKoZIzj0EAwIDSAAwRQIgQeA2iFTD
-u/a46ccjZoVXtvicaXn+dUeYbxyS6PToeDICIQDBEmh6g6rlLANVHNbC5zC2wWsY
-mHvml2cv5JFGTSYdtQ==
+MIIBuTCCAV+gAwIBAgIRAJy6V6Ss8fpxNeZQor0s0BYwCgYIKoZIzj0EAwIwJjEN
+MAsGA1UEChMEd2lyZTEVMBMGA1UEAxMMd2lyZSBSb290IENBMB4XDTI0MDExNjE1
+MDkxOFoXDTM0MDExMzE1MDkxOFowLjENMAsGA1UEChMEd2lyZTEdMBsGA1UEAxMU
+d2lyZSBJbnRlcm1lZGlhdGUgQ0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATJ
+IZgIKmrKQ9qqsvKsl+0frjdV+N+6LFx3FN0QVXDPFiQe4X2un88eeg79+fW3yXhi
+DHf196luRN3ydPvScAGgo2YwZDAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgw
+BgEB/wIBADAdBgNVHQ4EFgQUL5YqVyZXiMW5t/DGkuZdANPJ4HowHwYDVR0jBBgw
+FoAUfo7V/ISNlOldc1fr/SNvGrJcbV0wCgYIKoZIzj0EAwIDSAAwRQIgVeS/71Yn
+oM/M5UOBVjGOZjWI/gjFUY/YJOv8mNwi9E0CIQCWyfsrXjHY3cutjYWdRhYhcxnF
+QdjSQ8JcFoE8bVhyog==
 -----END CERTIFICATE-----
 
 ```
@@ -907,22 +1093,22 @@ Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number:
-            d9:5f:69:ac:93:c3:43:16:e0:57:86:22:29:32:00:5d
+            9c:ba:57:a4:ac:f1:fa:71:35:e6:50:a2:bd:2c:d0:16
         Signature Algorithm: ecdsa-with-SHA256
         Issuer: O=wire, CN=wire Root CA
         Validity
-            Not Before: Jan 15 16:27:27 2024 GMT
-            Not After : Jan 12 16:27:27 2034 GMT
+            Not Before: Jan 16 15:09:18 2024 GMT
+            Not After : Jan 13 15:09:18 2034 GMT
         Subject: O=wire, CN=wire Intermediate CA
         Subject Public Key Info:
             Public Key Algorithm: id-ecPublicKey
                 Public-Key: (256 bit)
                 pub:
-                    04:8c:ae:f6:da:84:6b:c2:84:e3:ac:e4:4a:ac:ee:
-                    aa:9d:42:f7:d7:35:3f:48:22:43:fb:f0:7c:66:f5:
-                    f3:51:2a:4e:21:1b:b5:07:8f:9c:75:47:45:5e:ea:
-                    41:1a:ed:7e:40:72:61:58:57:f5:3d:a0:bb:83:9f:
-                    56:4e:18:79:63
+                    04:c9:21:98:08:2a:6a:ca:43:da:aa:b2:f2:ac:97:
+                    ed:1f:ae:37:55:f8:df:ba:2c:5c:77:14:dd:10:55:
+                    70:cf:16:24:1e:e1:7d:ae:9f:cf:1e:7a:0e:fd:f9:
+                    f5:b7:c9:78:62:0c:77:f5:f7:a9:6e:44:dd:f2:74:
+                    fb:d2:70:01:a0
                 ASN1 OID: prime256v1
                 NIST CURVE: P-256
         X509v3 extensions:
@@ -931,15 +1117,15 @@ Certificate:
             X509v3 Basic Constraints: critical
                 CA:TRUE, pathlen:0
             X509v3 Subject Key Identifier: 
-                53:93:60:7A:2A:BE:BC:D2:03:71:69:93:35:E3:B4:2D:8A:54:8D:D2
+                2F:96:2A:57:26:57:88:C5:B9:B7:F0:C6:92:E6:5D:00:D3:C9:E0:7A
             X509v3 Authority Key Identifier: 
-                01:CD:D5:23:97:4F:8F:32:4C:1D:BB:1A:90:A2:26:6D:22:B6:EA:CA
+                7E:8E:D5:FC:84:8D:94:E9:5D:73:57:EB:FD:23:6F:1A:B2:5C:6D:5D
     Signature Algorithm: ecdsa-with-SHA256
     Signature Value:
-        30:45:02:20:41:e0:36:88:54:c3:bb:f6:b8:e9:c7:23:66:85:
-        57:b6:f8:9c:69:79:fe:75:47:98:6f:1c:92:e8:f4:e8:78:32:
-        02:21:00:c1:12:68:7a:83:aa:e5:2c:03:55:1c:d6:c2:e7:30:
-        b6:c1:6b:18:98:7b:e6:97:67:2f:e4:91:46:4d:26:1d:b5
+        30:45:02:20:55:e4:bf:ef:56:27:a0:cf:cc:e5:43:81:56:31:
+        8e:66:35:88:fe:08:c5:51:8f:d8:24:eb:fc:98:dc:22:f4:4d:
+        02:21:00:96:c9:fb:2b:5e:31:d8:dd:cb:ad:8d:85:9d:46:16:
+        21:73:19:c5:41:d8:d2:43:c2:5c:16:81:3c:6d:58:72:a2
 
 ```
 
@@ -947,15 +1133,15 @@ Certificate:
 
 ```
 -----BEGIN CERTIFICATE-----
-MIIBjzCCATWgAwIBAgIQNH6gnI8ByM3lcP/r0KjiyjAKBggqhkjOPQQDAjAmMQ0w
-CwYDVQQKEwR3aXJlMRUwEwYDVQQDEwx3aXJlIFJvb3QgQ0EwHhcNMjQwMTE1MTYy
-NzI2WhcNMzQwMTEyMTYyNzI2WjAmMQ0wCwYDVQQKEwR3aXJlMRUwEwYDVQQDEwx3
-aXJlIFJvb3QgQ0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAR4NOweoDv4pT6M
-pPqsDUdgSd8tGPUzynZYq6zUvL9Tpr6yj2Xsn9pUTb9E9nb8l8IKZJx4wJMdhP2u
-POBu8zdjo0UwQzAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgwBgEB/wIBATAd
-BgNVHQ4EFgQUAc3VI5dPjzJMHbsakKImbSK26sowCgYIKoZIzj0EAwIDSAAwRQIg
-J1gV4hJjvZCerYOs3EicV3CEl6aHhoQ3KbbFxc/uUUwCIQDWrCSEQvPVDNCVIcCc
-9+KK5XWocbeVbAySZ3OByhsMtQ==
+MIIBkDCCATWgAwIBAgIQI+8WrQnQcG1/veRnq6RqsTAKBggqhkjOPQQDAjAmMQ0w
+CwYDVQQKEwR3aXJlMRUwEwYDVQQDEwx3aXJlIFJvb3QgQ0EwHhcNMjQwMTE2MTUw
+OTE3WhcNMzQwMTEzMTUwOTE3WjAmMQ0wCwYDVQQKEwR3aXJlMRUwEwYDVQQDEwx3
+aXJlIFJvb3QgQ0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAShTvawJEV5XIUB
+CawfGaXUI2dvg3iSNqiT5AeYyHsHwG8dXGaLJH8eBuOGTXo4Jpr9+0RacmyaDkIq
+1g2gN1b/o0UwQzAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgwBgEB/wIBATAd
+BgNVHQ4EFgQUfo7V/ISNlOldc1fr/SNvGrJcbV0wCgYIKoZIzj0EAwIDSQAwRgIh
+APrydq1uv6NJPApolkm7yljrE/1WDpCbXy9AtLO3Jss9AiEA9M0ku60C21voy1Cf
+xjrvE+FOa3AdOtIQMtSWNPhSm4A=
 -----END CERTIFICATE-----
 
 ```
@@ -964,22 +1150,22 @@ Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number:
-            34:7e:a0:9c:8f:01:c8:cd:e5:70:ff:eb:d0:a8:e2:ca
+            23:ef:16:ad:09:d0:70:6d:7f:bd:e4:67:ab:a4:6a:b1
         Signature Algorithm: ecdsa-with-SHA256
         Issuer: O=wire, CN=wire Root CA
         Validity
-            Not Before: Jan 15 16:27:26 2024 GMT
-            Not After : Jan 12 16:27:26 2034 GMT
+            Not Before: Jan 16 15:09:17 2024 GMT
+            Not After : Jan 13 15:09:17 2034 GMT
         Subject: O=wire, CN=wire Root CA
         Subject Public Key Info:
             Public Key Algorithm: id-ecPublicKey
                 Public-Key: (256 bit)
                 pub:
-                    04:78:34:ec:1e:a0:3b:f8:a5:3e:8c:a4:fa:ac:0d:
-                    47:60:49:df:2d:18:f5:33:ca:76:58:ab:ac:d4:bc:
-                    bf:53:a6:be:b2:8f:65:ec:9f:da:54:4d:bf:44:f6:
-                    76:fc:97:c2:0a:64:9c:78:c0:93:1d:84:fd:ae:3c:
-                    e0:6e:f3:37:63
+                    04:a1:4e:f6:b0:24:45:79:5c:85:01:09:ac:1f:19:
+                    a5:d4:23:67:6f:83:78:92:36:a8:93:e4:07:98:c8:
+                    7b:07:c0:6f:1d:5c:66:8b:24:7f:1e:06:e3:86:4d:
+                    7a:38:26:9a:fd:fb:44:5a:72:6c:9a:0e:42:2a:d6:
+                    0d:a0:37:56:ff
                 ASN1 OID: prime256v1
                 NIST CURVE: P-256
         X509v3 extensions:
@@ -988,13 +1174,13 @@ Certificate:
             X509v3 Basic Constraints: critical
                 CA:TRUE, pathlen:1
             X509v3 Subject Key Identifier: 
-                01:CD:D5:23:97:4F:8F:32:4C:1D:BB:1A:90:A2:26:6D:22:B6:EA:CA
+                7E:8E:D5:FC:84:8D:94:E9:5D:73:57:EB:FD:23:6F:1A:B2:5C:6D:5D
     Signature Algorithm: ecdsa-with-SHA256
     Signature Value:
-        30:45:02:20:27:58:15:e2:12:63:bd:90:9e:ad:83:ac:dc:48:
-        9c:57:70:84:97:a6:87:86:84:37:29:b6:c5:c5:cf:ee:51:4c:
-        02:21:00:d6:ac:24:84:42:f3:d5:0c:d0:95:21:c0:9c:f7:e2:
-        8a:e5:75:a8:71:b7:95:6c:0c:92:67:73:81:ca:1b:0c:b5
+        30:46:02:21:00:fa:f2:76:ad:6e:bf:a3:49:3c:0a:68:96:49:
+        bb:ca:58:eb:13:fd:56:0e:90:9b:5f:2f:40:b4:b3:b7:26:cb:
+        3d:02:21:00:f4:cd:24:bb:ad:02:db:5b:e8:cb:50:9f:c6:3a:
+        ef:13:e1:4e:6b:70:1d:3a:d2:10:32:d4:96:34:f8:52:9b:80
 
 ```
 

--- a/e2e-identity/src/types.rs
+++ b/e2e-identity/src/types.rs
@@ -37,10 +37,9 @@ pub struct E2eiNewAcmeOrder {
 #[serde(rename_all = "camelCase")]
 pub struct E2eiNewAcmeAuthz {
     pub identifier: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub wire_dpop_challenge: Option<E2eiAcmeChall>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub wire_oidc_challenge: Option<E2eiAcmeChall>,
+    pub keyauth: String,
+    pub wire_dpop_challenge: E2eiAcmeChall,
+    pub wire_oidc_challenge: E2eiAcmeChall,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/e2e-identity/tests/api.rs
+++ b/e2e-identity/tests/api.rs
@@ -144,12 +144,7 @@ fn e2e_api() {
         };
 
         // extract challenges
-        let (dpop_chall, oidc_chall) = {
-            (
-                authz.wire_dpop_challenge.clone().unwrap(),
-                authz.wire_oidc_challenge.clone().unwrap(),
-            )
-        };
+        let (dpop_chall, oidc_chall) = { (authz.wire_dpop_challenge.clone(), authz.wire_oidc_challenge.clone()) };
 
         // HEAD http://wire-server/nonce
         let backend_nonce = { BackendNonce::from(utils::rand_base64_str(32)) };

--- a/e2e-identity/tests/utils/cfg.rs
+++ b/e2e-identity/tests/utils/cfg.rs
@@ -15,6 +15,7 @@ use crate::utils::{
     display::TestDisplay,
     docker::{
         dex::{DexCfg, DexImage, DexServer},
+        keycloak::{KeycloakCfg, KeycloakImage, KeycloakServer},
         ldap::{LdapCfg, LdapImage, LdapServer},
         stepca::{AcmeServer, CaCfg, StepCaImage},
     },
@@ -32,6 +33,7 @@ pub struct E2eTest<'a> {
     pub handle: String,
     pub ldap_cfg: LdapCfg,
     pub dex_cfg: DexCfg,
+    pub keycloak_cfg: KeycloakCfg,
     pub ca_cfg: CaCfg,
     pub oauth_cfg: OauthCfg,
     pub backend_kp: Pem,
@@ -44,6 +46,7 @@ pub struct E2eTest<'a> {
     pub display: TestDisplay,
     pub wire_server: Option<WireServer>,
     pub ldap_server: Option<LdapServer<'a>>,
+    pub keycloak_server: Option<KeycloakServer<'a>>,
     pub dex_server: Option<DexServer<'a>>,
     pub acme_server: Option<AcmeServer<'a>>,
     pub oidc_cfg: Option<OidcCfg>,
@@ -54,6 +57,7 @@ pub struct E2eTest<'a> {
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum OidcProvider {
     Dex,
+    Keycloak,
     Google,
 }
 
@@ -61,11 +65,9 @@ unsafe impl<'a> Send for E2eTest<'a> {}
 unsafe impl<'a> Sync for E2eTest<'a> {}
 
 impl<'a> E2eTest<'a> {
-    const DEX_HOST: &'static str = "dex";
     const STEPCA_HOST: &'static str = "stepca";
     const LDAP_HOST: &'static str = "ldap";
     const WIRE_HOST: &'static str = "wire.com";
-    const HOSTS: [&'static str; 4] = [Self::DEX_HOST, Self::STEPCA_HOST, Self::LDAP_HOST, Self::WIRE_HOST];
 
     pub fn default_template(org: &str) -> String {
         // we use '{' to escape '{'. That's why we sometimes have 4: this uses handlebars template
@@ -73,9 +75,9 @@ impl<'a> E2eTest<'a> {
             r#"{{
         	"subject": {{
         	    "organization": "{org}",
-        	    "commonName": {{{{ toJson .Oidc.preferred_username }}}}
+        	    "commonName": {{{{ toJson .Oidc.name }}}}
         	}},
-        	"uris": [{{{{ toJson .Oidc.name }}}}, {{{{ toJson .Dpop.sub }}}}],
+        	"uris": [{{{{ toJson .Oidc.preferred_username }}}}, {{{{ toJson .Dpop.sub }}}}],
         	"keyUsage": ["digitalSignature"],
         	"extKeyUsage": ["clientAuth"]
         }}"#
@@ -83,21 +85,28 @@ impl<'a> E2eTest<'a> {
     }
 
     pub fn new() -> Self {
-        Self::new_internal(false, JwsAlgorithm::Ed25519)
+        Self::new_internal(false, JwsAlgorithm::Ed25519, OidcProvider::Keycloak)
     }
 
     pub fn new_demo() -> Self {
-        Self::new_internal(true, JwsAlgorithm::Ed25519)
+        Self::new_internal(true, JwsAlgorithm::Ed25519, OidcProvider::Keycloak)
     }
 
-    pub fn new_internal(is_demo: bool, alg: JwsAlgorithm) -> Self {
-        let [dex_host, ca_host, ldap_host, domain] = if is_demo {
-            Self::HOSTS.map(|h| h.to_string())
+    pub fn new_internal(is_demo: bool, alg: JwsAlgorithm, oidc_provider: OidcProvider) -> Self {
+        let idp_host = match oidc_provider {
+            OidcProvider::Dex => "dex",
+            OidcProvider::Keycloak => "keycloak",
+            OidcProvider::Google => "",
+        };
+        let hosts = [idp_host, Self::STEPCA_HOST, Self::LDAP_HOST, Self::WIRE_HOST];
+        let [idp_host, ca_host, ldap_host, domain] = if is_demo {
+            hosts.map(|h| h.to_string())
         } else {
-            Self::HOSTS.map(|h| format!("{h}.{}", rand_str(6).to_lowercase()))
+            hosts.map(|h| format!("{h}.{}", rand_str(6).to_lowercase()))
         };
 
-        let display_name = "Alice Smith";
+        let (firstname, lastname) = ("Alice", "Smith");
+        let display_name = format!("{firstname} {lastname}");
         let wire_user_id = uuid::Uuid::new_v4();
         let wire_client_id = random::<u64>();
         let sub = ClientId::try_new(wire_user_id.to_string(), wire_client_id, &domain).unwrap();
@@ -106,11 +115,31 @@ impl<'a> E2eTest<'a> {
         let email = format!("alicesmith@{domain}");
         let audience = "wireapp";
         let client_secret = rand_base64_str(24);
-        let dex_host_port = portpicker::pick_unused_port().unwrap();
-        let issuer = format!("http://{dex_host}:{dex_host_port}/dex");
-        // this will be called from Docker network so we don't want to use the host port
-        // TODO: support https for jwks uri
-        let jwks_uri = format!("http://{dex_host}:{}/dex/keys", DexImage::PORT);
+        let idp_host_port = portpicker::pick_unused_port().unwrap();
+        let idp_base = format!("http://{idp_host}");
+        let (issuer, jwks_uri) = match oidc_provider {
+            OidcProvider::Dex => {
+                // this will be called from Docker network so we don't want to use the host port
+                let docker_port = DexImage::PORT;
+                (
+                    format!("{idp_base}:{idp_host_port}/dex"),
+                    format!("{idp_base}:{docker_port}/dex/keys"),
+                )
+            }
+            OidcProvider::Keycloak => {
+                let realm = KeycloakImage::REALM;
+                // this will be called from Docker network so we don't want to use the host port
+                let docker_port = KeycloakImage::HTTP_PORT;
+                (
+                    format!("{idp_base}:{idp_host_port}/realms/{realm}"),
+                    format!("{idp_base}:{docker_port}/realms/{realm}/protocol/openid-connect/certs",),
+                )
+            }
+            OidcProvider::Google => (
+                "https://accounts.google.com".to_string(),
+                "https://www.googleapis.com/oauth2/v3/certs".to_string(),
+            ),
+        };
 
         let (client_kp, sign_key, backend_kp, acme_kp, acme_jwk) = match alg {
             JwsAlgorithm::Ed25519 => {
@@ -166,19 +195,30 @@ impl<'a> E2eTest<'a> {
                 host: ldap_host.to_string(),
                 display_name: display_name.to_string(),
                 handle: qualified_handle.to_string(),
-                email,
+                email: email.clone(),
                 password: password.to_string(),
                 domain: domain.to_string(),
                 sub: sub.to_uri(),
             },
             dex_cfg: DexCfg {
-                host: dex_host,
+                host: idp_host.clone(),
                 ldap_host,
-                host_port: dex_host_port,
+                host_port: idp_host_port,
                 issuer: issuer.to_string(),
                 client_id: audience.to_string(),
                 client_secret: client_secret.to_string(),
                 domain,
+            },
+            keycloak_cfg: KeycloakCfg {
+                oauth_client_id: audience.to_string(),
+                http_host_port: idp_host_port,
+                https_host_port: portpicker::pick_unused_port().unwrap(),
+                host: idp_host,
+                firstname: firstname.to_string(),
+                lastname: lastname.to_string(),
+                username: qualified_handle.to_string(),
+                email,
+                password: password.to_string(),
             },
             ca_cfg: CaCfg {
                 sign_key,
@@ -205,11 +245,12 @@ impl<'a> E2eTest<'a> {
             wire_server: None,
             ldap_server: None,
             dex_server: None,
+            keycloak_server: None,
             acme_server: None,
             oidc_cfg: None,
             is_demo,
             client: reqwest::Client::new(),
-            oidc_provider: OidcProvider::Dex,
+            oidc_provider,
         }
     }
 
@@ -221,7 +262,9 @@ impl<'a> E2eTest<'a> {
 
         // wire-server
         let (wire_server_host, wire_server_port, redirect) = match self.oidc_provider {
-            OidcProvider::Dex => (self.domain.clone(), portpicker::pick_unused_port().unwrap(), "callback"),
+            OidcProvider::Dex | OidcProvider::Keycloak => {
+                (self.domain.clone(), portpicker::pick_unused_port().unwrap(), "callback")
+            }
             // need to use a fixed port for Google in order to have a constant redirect_uri
             OidcProvider::Google => ("localhost".to_string(), 9090, "callback-google"),
         };
@@ -233,15 +276,23 @@ impl<'a> E2eTest<'a> {
         let mut dns_mappings = HashMap::<String, SocketAddr, RandomState>::new();
 
         // start OIDC server
-        if self.oidc_provider == OidcProvider::Dex {
-            // LDAP (required by Dex)
-            let ldap_server = LdapImage::run(docker, self.ldap_cfg.clone());
-            self.ldap_server = Some(ldap_server);
+        match self.oidc_provider {
+            OidcProvider::Dex => {
+                // LDAP (required by Dex)
+                let ldap_server = LdapImage::run(docker, self.ldap_cfg.clone());
+                self.ldap_server = Some(ldap_server);
 
-            // Dex (OIDC provider)
-            let dex_server = DexImage::run(docker, self.dex_cfg.clone(), redirect_uri.clone());
-            dns_mappings.insert(self.dex_cfg.host.clone(), dex_server.socket);
-            self.dex_server = Some(dex_server);
+                // Dex (OIDC provider)
+                let dex_server = DexImage::run(docker, self.dex_cfg.clone(), redirect_uri.clone());
+                dns_mappings.insert(self.dex_cfg.host.clone(), dex_server.socket);
+                self.dex_server = Some(dex_server);
+            }
+            OidcProvider::Keycloak => {
+                let keycloak_server = KeycloakImage::run(docker, self.keycloak_cfg.clone(), redirect_uri.clone()).await;
+                dns_mappings.insert(self.keycloak_cfg.host.clone(), keycloak_server.socket);
+                self.keycloak_server = Some(keycloak_server);
+            }
+            OidcProvider::Google => {}
         }
 
         // start ACME server
@@ -286,11 +337,18 @@ impl<'a> E2eTest<'a> {
 
     pub async fn fetch_oidc_cfg(&self) -> OidcCfg {
         let authz_server_uri = match self.oidc_provider {
-            OidcProvider::Dex => self.authorization_server_uri(),
+            OidcProvider::Dex => self.dex_authorization_server_uri(),
+            OidcProvider::Keycloak => self.keycloak_server.as_ref().unwrap().http_uri.clone(),
             OidcProvider::Google => "https://accounts.google.com".to_string(),
         };
         let uri = match self.oidc_provider {
             OidcProvider::Dex => format!("{authz_server_uri}/dex/.well-known/openid-configuration"),
+            OidcProvider::Keycloak => {
+                format!(
+                    "{authz_server_uri}/realms/{}/.well-known/openid-configuration",
+                    KeycloakImage::REALM
+                )
+            }
             OidcProvider::Google => "https://accounts.google.com/.well-known/openid-configuration".to_string(),
         };
         let resp = self.client.get(&uri).send().await.unwrap();
@@ -316,7 +374,7 @@ impl<'a> E2eTest<'a> {
         format!("{}/callback", self.wire_server_uri())
     }
 
-    pub fn authorization_server_uri(&self) -> String {
+    pub fn dex_authorization_server_uri(&self) -> String {
         self.dex_server.as_ref().unwrap().uri.clone()
     }
 
@@ -372,7 +430,7 @@ pub struct EnrollmentFlow {
     pub create_dpop_token: Flow<(AcmeChallenge, BackendNonce, QualifiedHandle, Team, core::time::Duration), String>,
     pub get_access_token: Flow<(AcmeChallenge, String), String>,
     pub verify_dpop_challenge: Flow<(AcmeAccount, AcmeChallenge, String, String), String>,
-    pub fetch_id_token: Flow<AcmeChallenge, String>,
+    pub fetch_id_token: Flow<(AcmeChallenge, String), String>,
     pub verify_oidc_challenge: Flow<(AcmeAccount, AcmeChallenge, String, String), String>,
     pub verify_order_status: Flow<(AcmeAccount, url::Url, String), (AcmeOrder, String)>,
     pub finalize: Flow<(AcmeAccount, AcmeOrder, String), (AcmeFinalize, String)>,
@@ -447,9 +505,9 @@ impl Default for EnrollmentFlow {
                     Ok((test, previous_nonce))
                 })
             }),
-            fetch_id_token: Box::new(|mut test, oidc_chall| {
+            fetch_id_token: Box::new(|mut test, (oidc_chall, keyauth)| {
                 Box::pin(async move {
-                    let id_token = test.fetch_id_token(&oidc_chall).await?;
+                    let id_token = test.fetch_id_token(&oidc_chall, keyauth).await?;
                     Ok((test, id_token))
                 })
             }),

--- a/e2e-identity/tests/utils/display.rs
+++ b/e2e-identity/tests/utils/display.rs
@@ -59,12 +59,12 @@ impl TestDisplay {
         self.events.push(event);
     }
 
-    pub fn display_token(&mut self, label: &str, token: &str, alg: Option<JwsAlgorithm>, keypair: String) {
+    pub fn display_token(&mut self, label: &str, token: &str, alg: Option<JwsAlgorithm>, keypair: &str) {
         let event = Event::Token {
             label: label.to_string(),
             token: token.to_string(),
             alg,
-            pk: keypair,
+            pk: keypair.to_string(),
         };
         event.println();
         self.markdown.push(event.markdown());

--- a/e2e-identity/tests/utils/docker/dex.rs
+++ b/e2e-identity/tests/utils/docker/dex.rs
@@ -1,7 +1,8 @@
-use std::{collections::HashMap, net::SocketAddr, path::PathBuf};
+use std::{collections::HashMap, net::SocketAddr};
+
+use testcontainers::{clients::Cli, core::WaitFor, Container, Image, RunnableImage};
 
 use crate::utils::docker::{ldap::LdapCfg, rand_str, SHM};
-use testcontainers::{clients::Cli, core::WaitFor, Container, Image, RunnableImage};
 
 pub struct DexServer<'a> {
     pub uri: String,
@@ -13,7 +14,6 @@ pub struct DexServer<'a> {
 pub struct DexImage {
     pub volumes: HashMap<String, String>,
     pub env_vars: HashMap<String, String>,
-    pub cfg_file: PathBuf,
 }
 
 impl DexImage {
@@ -51,7 +51,6 @@ impl DexImage {
         Self {
             volumes: HashMap::from_iter(vec![(host_vol_str, "/etc/dex/config.docker.yaml".to_string())]),
             env_vars: HashMap::new(),
-            cfg_file: host_cfg_file,
         }
     }
 }

--- a/e2e-identity/tests/utils/docker/keycloak.rs
+++ b/e2e-identity/tests/utils/docker/keycloak.rs
@@ -1,0 +1,233 @@
+use std::{collections::HashMap, env, net::SocketAddr};
+
+use keycloak::{
+    types::ProtocolMapperRepresentation,
+    types::{ClientRepresentation, CredentialRepresentation, UserRepresentation},
+    KeycloakAdmin, KeycloakAdminToken,
+};
+use serde_json::json;
+use testcontainers::{clients::Cli, core::WaitFor, Container, Image, ImageArgs, RunnableImage};
+
+use crate::utils::docker::SHM;
+
+pub struct KeycloakServer<'a> {
+    pub http_uri: String,
+    pub https_uri: String,
+    pub node: Container<'a, KeycloakImage>,
+    pub socket: SocketAddr,
+}
+
+#[derive(Debug)]
+pub struct KeycloakImage {
+    pub volumes: HashMap<String, String>,
+    pub env_vars: HashMap<String, String>,
+}
+
+impl KeycloakImage {
+    const NAME: &'static str = "quay.io/keycloak/keycloak";
+    const TAG: &'static str = "22.0.5"; // has to match the version of Keycloak crate
+    pub const HTTP_PORT: u16 = 8080;
+    pub const HTTPS_PORT: u16 = 8443;
+
+    pub const USER: &'static str = "admin";
+    pub const PASSWORD: &'static str = "changeme";
+    pub const REALM: &'static str = "master";
+    pub const LOG_LEVEL: &'static str = "info";
+
+    pub async fn run(docker: &Cli, cfg: KeycloakCfg, redirect_uri: String) -> KeycloakServer {
+        let instance = Self::new();
+        let image: RunnableImage<Self> = instance.into();
+        let image = image
+            .with_container_name(&cfg.host)
+            .with_network(super::NETWORK)
+            .with_mapped_port((cfg.http_host_port, Self::HTTP_PORT))
+            .with_mapped_port((cfg.https_host_port, Self::HTTPS_PORT))
+            .with_privileged(true)
+            .with_shm_size(SHM);
+        let node = docker.run(image);
+
+        let http_port = node.get_host_port_ipv4(Self::HTTP_PORT);
+        let http_uri = format!("http://{}:{http_port}", cfg.host);
+
+        let https_port = node.get_host_port_ipv4(Self::HTTPS_PORT);
+        let https_uri = format!("http://{}:{https_port}", cfg.host);
+
+        let ip = std::net::IpAddr::V4("127.0.0.1".parse().unwrap());
+        let socket = SocketAddr::new(ip, http_port);
+
+        Self::configure(http_port, &cfg, &redirect_uri).await;
+
+        KeycloakServer {
+            http_uri,
+            https_uri,
+            socket,
+            node,
+        }
+    }
+
+    pub fn new() -> Self {
+        Self {
+            volumes: HashMap::new(),
+            env_vars: HashMap::from_iter(vec![
+                ("KEYCLOAK_ADMIN".to_string(), Self::USER.to_string()),
+                ("KEYCLOAK_ADMIN_PASSWORD".to_string(), Self::PASSWORD.to_string()),
+                ("KC_LOG_LEVEL".to_string(), Self::LOG_LEVEL.to_string()),
+            ]),
+        }
+    }
+
+    async fn configure(external_port: u16, cfg: &KeycloakCfg, redirect_uri: &str) {
+        let url = format!("http://localhost:{external_port}");
+        let user = Self::USER.to_string();
+        let password = Self::PASSWORD.to_string();
+        let client = reqwest::Client::new();
+        let admin_token = KeycloakAdminToken::acquire(&url, &user, &password, &client)
+            .await
+            .unwrap();
+        let admin = KeycloakAdmin::new(&url, admin_token, client);
+
+        // Create a User for the test
+        let user = cfg.into();
+        admin.realm_users_post(Self::REALM, user).await.unwrap();
+
+        // Then create an OAuth public Client (w/o client-secret)
+        let client = ClientRepresentation {
+            client_id: Some(cfg.oauth_client_id.clone()),
+            name: Some("wireapp-oauth-client".to_string()),
+            consent_required: Some(false),
+            always_display_in_console: Some(true),
+            enabled: Some(true),
+            implicit_flow_enabled: Some(false),
+            standard_flow_enabled: Some(true),
+            redirect_uris: Some(vec![redirect_uri.to_string()]),
+            public_client: Some(true),
+            ..Default::default()
+        };
+        admin.realm_clients_post(Self::REALM, client).await.unwrap();
+
+        // Now we need to turn on the "oidc-claims-param-token-mapper" mapper to activate the claims request mapping
+        // https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter
+        // (event though the discovery endpoint already advertises supporting it)
+        let component_type = "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy";
+        let components = admin
+            .realm_components_get(Self::REALM, None, None, Some(component_type.to_string()))
+            .await
+            .unwrap();
+        let mut component = components
+            .into_iter()
+            .find(|c| {
+                c.provider_id == Some("allowed-protocol-mappers".to_string())
+                    && c.name == Some("Allowed Protocol Mapper Types".to_string())
+                    && c.sub_type == Some("anonymous".to_string())
+            })
+            .unwrap();
+
+        let component_id = component.id.as_ref().unwrap();
+        if let Some(component_cfg) = component.config.as_mut() {
+            component_cfg
+                .entry("allowed-protocol-mapper-types".to_string())
+                .and_modify(|e| {
+                    e.push(json!("oidc-claims-param-value-idtoken-mapper"));
+                });
+        }
+
+        admin
+            .realm_components_with_id_put(Self::REALM, component_id, component.clone())
+            .await
+            .unwrap();
+
+        // Now enable the mapper for the scope "profile"
+        // First find the scope "profile"
+        let scopes = admin.realm_client_scopes_get(Self::REALM).await.unwrap();
+        let profile_scope = scopes.iter().find(|s| s.name == Some("profile".to_string())).unwrap();
+
+        // Then register this protocol mapper for this scope
+        let scope_id = profile_scope.id.clone().unwrap();
+        let protocol_mapper = ProtocolMapperRepresentation {
+            config: Some(HashMap::from_iter([
+                ("claim.name".to_string(), json!("keyauth")),
+                ("id.token.claim".to_string(), json!("true")),
+            ])),
+            name: Some("wire-keyauth-id-token-mapper".to_string()),
+            protocol: Some("openid-connect".to_string()),
+            protocol_mapper: Some("oidc-claims-param-value-idtoken-mapper".to_string()),
+            ..Default::default()
+        };
+        admin
+            .realm_client_scopes_with_id_protocol_mappers_models_post(Self::REALM, &scope_id, protocol_mapper)
+            .await
+            .unwrap();
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct KeycloakCfg {
+    pub oauth_client_id: String,
+    pub firstname: String,
+    pub lastname: String,
+    pub username: String,
+    pub email: String,
+    pub password: String,
+    pub host: String,
+    pub http_host_port: u16,
+    pub https_host_port: u16,
+}
+
+impl From<&KeycloakCfg> for UserRepresentation {
+    fn from(cfg: &KeycloakCfg) -> Self {
+        Self {
+            username: Some(cfg.username.clone()),
+            email: Some(cfg.email.clone()),
+            enabled: Some(true),
+            email_verified: Some(true),
+            first_name: Some(cfg.firstname.clone()),
+            last_name: Some(cfg.lastname.clone()),
+            credentials: Some(vec![CredentialRepresentation {
+                temporary: Some(false),
+                value: Some("foo".to_string()),
+                credential_data: Some("foo".to_string()),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }
+    }
+}
+
+impl Image for KeycloakImage {
+    type Args = KeycloakArgs;
+
+    fn name(&self) -> String {
+        Self::NAME.to_string()
+    }
+
+    fn tag(&self) -> String {
+        env::var("KEYCLOAK_VERSION").unwrap_or_else(|_| Self::TAG.to_string())
+    }
+
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        let msg = format!("Keycloak {} on JVM", Self::TAG);
+        vec![WaitFor::message_on_stdout(msg)]
+    }
+
+    fn env_vars(&self) -> Box<dyn Iterator<Item = (&String, &String)> + '_> {
+        Box::new(self.env_vars.iter())
+    }
+
+    fn volumes(&self) -> Box<dyn Iterator<Item = (&String, &String)> + '_> {
+        Box::new(self.volumes.iter())
+    }
+
+    fn expose_ports(&self) -> Vec<u16> {
+        vec![KeycloakImage::HTTP_PORT, KeycloakImage::HTTPS_PORT]
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct KeycloakArgs;
+
+impl ImageArgs for KeycloakArgs {
+    fn into_iterator(self) -> Box<dyn Iterator<Item = String>> {
+        let options = ["--verbose", "start-dev"].map(str::to_string);
+        Box::new(options.into_iter())
+    }
+}

--- a/e2e-identity/tests/utils/docker/mod.rs
+++ b/e2e-identity/tests/utils/docker/mod.rs
@@ -1,6 +1,7 @@
 #![cfg(not(target_family = "wasm"))]
 
 pub mod dex;
+pub mod keycloak;
 pub mod ldap;
 pub mod stepca;
 pub mod wiremock;

--- a/e2e-identity/tests/utils/docker/stepca.rs
+++ b/e2e-identity/tests/utils/docker/stepca.rs
@@ -101,7 +101,7 @@ pub struct StepCaImage {
 
 impl StepCaImage {
     const NAME: &'static str = "quay.io/wire/smallstep-acme";
-    const TAG: &'static str = "0.0.42-test.106";
+    const TAG: &'static str = "0.0.42-test.109";
     const CA_NAME: &'static str = "wire";
     pub const ACME_PROVISIONER: &'static str = "wire";
     pub const PORT: u16 = 9000;


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

'keyauth' was carried alongside the ACME request body because of a limitation of Dex. No it can safely be sealed in the Id token

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
