### PR TITLE
feat!: add support for SHA-512 and stop hardcoding SHA-256 for MLS thumbprint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,6 +2332,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3262,6 +3276,7 @@ dependencies = [
  "lazy_static",
  "p256",
  "p384",
+ "p521",
  "percent-encoding",
  "rand 0.8.5",
  "rand_chacha 0.3.1",

--- a/acme/src/certificate.rs
+++ b/acme/src/certificate.rs
@@ -28,6 +28,7 @@ impl RustyAcme {
     pub fn certificate_response(
         response: String,
         order: AcmeOrder,
+        hash_alg: HashAlgorithm,
         env: Option<&PkiEnvironment>,
     ) -> RustyAcmeResult<Vec<Vec<u8>>> {
         order.verify()?;
@@ -48,7 +49,7 @@ impl RustyAcme {
 
                 // only verify that leaf has the right identity fields
                 if i == 0 {
-                    Self::verify_leaf_certificate(cert, &order.try_get_coalesce_identifier()?, env)?;
+                    Self::verify_leaf_certificate(cert, &order.try_get_coalesce_identifier()?, hash_alg, env)?;
                 }
                 acc.push(cert_pem.contents().to_vec());
                 Ok(acc)
@@ -60,10 +61,11 @@ impl RustyAcme {
     fn verify_leaf_certificate(
         cert: Certificate,
         identifier: &CanonicalIdentifier,
+        hash_alg: HashAlgorithm,
         env: Option<&PkiEnvironment>,
     ) -> RustyAcmeResult<()> {
         // TODO: verify that cert is signed by enrollment.sign_kp
-        let cert_identity = cert.extract_identity(env)?;
+        let cert_identity = cert.extract_identity(env, hash_alg)?;
 
         let invalid_client_id =
             ClientId::try_from_qualified(&cert_identity.client_id)? != ClientId::try_from_uri(&identifier.client_id)?;

--- a/acme/src/finalize.rs
+++ b/acme/src/finalize.rs
@@ -62,6 +62,7 @@ impl RustyAcme {
             JwsAlgorithm::Ed25519 => oid_registry::OID_SIG_ED25519,
             JwsAlgorithm::P256 => oid_registry::OID_SIG_ECDSA_WITH_SHA256,
             JwsAlgorithm::P384 => oid_registry::OID_SIG_ECDSA_WITH_SHA384,
+            JwsAlgorithm::P521 => oid_registry::OID_SIG_ECDSA_WITH_SHA512,
         };
         Self::into_asn1_alg(oid, None)
     }
@@ -121,6 +122,7 @@ impl RustyAcme {
                 )?;
                 (pk, alg)
             }
+            JwsAlgorithm::P521 => return Err(RustyAcmeError::NotSupported),
         };
         let subject_public_key = x509_cert::der::asn1::BitString::new(0, pk)?;
         Ok(x509_cert::spki::SubjectPublicKeyInfoOwned {
@@ -180,6 +182,7 @@ impl RustyAcme {
                 let signature: p384::ecdsa::DerSignature = sk.try_sign(&cert_data)?;
                 x509_cert::der::asn1::BitString::new(0, signature.to_der()?)?
             }
+            JwsAlgorithm::P521 => return Err(RustyAcmeError::NotSupported),
         };
         Ok(signature)
     }

--- a/acme/src/identity/thumbprint.rs
+++ b/acme/src/identity/thumbprint.rs
@@ -19,16 +19,19 @@ pub fn compute_raw_key_thumbprint(
         JwsAlgorithm::Ed25519 => Ed25519PublicKey::from_bytes(signature_public_key)?.try_into_jwk()?,
         JwsAlgorithm::P256 => ES256PublicKey::from_bytes(signature_public_key)?.try_into_jwk()?,
         JwsAlgorithm::P384 => ES384PublicKey::from_bytes(signature_public_key)?.try_into_jwk()?,
+        JwsAlgorithm::P521 => return Err(RustyAcmeError::NotSupported),
     };
     let thumbprint = JwkThumbprint::generate(&jwk, hash_alg)?;
     Ok(thumbprint.kid)
 }
 
 /// See: https://datatracker.ietf.org/doc/html/rfc8037#appendix-A.3
-pub(crate) fn try_compute_jwk_canonicalized_thumbprint(cert: &x509_cert::TbsCertificate) -> RustyAcmeResult<String> {
+pub(crate) fn try_compute_jwk_canonicalized_thumbprint(
+    cert: &x509_cert::TbsCertificate,
+    hash_alg: HashAlgorithm,
+) -> RustyAcmeResult<String> {
     let jwk = try_into_jwk(&cert.subject_public_key_info)?;
-    // Hash is always SHA-256
-    let thumbprint = JwkThumbprint::generate(&jwk, HashAlgorithm::SHA256)?;
+    let thumbprint = JwkThumbprint::generate(&jwk, hash_alg)?;
     Ok(thumbprint.kid)
 }
 

--- a/cli/src/access_generate.rs
+++ b/cli/src/access_generate.rs
@@ -1,4 +1,5 @@
 use crate::{pem::*, utils::*};
+use anyhow::anyhow;
 use clap::Parser;
 use jwt_simple::prelude::*;
 use rusty_jwt_tools::prelude::*;
@@ -63,6 +64,7 @@ impl AccessGenerate {
         let client_kp = match alg {
             JwsAlgorithm::P256 => ES256KeyPair::generate().to_pem().unwrap().into(),
             JwsAlgorithm::P384 => ES384KeyPair::generate().to_pem().unwrap().into(),
+            JwsAlgorithm::P521 => return Err(anyhow!("P521 not supported")),
             JwsAlgorithm::Ed25519 => Ed25519KeyPair::generate().to_pem().into(),
         };
 

--- a/cli/src/jwk.rs
+++ b/cli/src/jwk.rs
@@ -1,4 +1,5 @@
 use crate::{pem::parse_key_pair_pem, utils::*};
+use anyhow::anyhow;
 use clap::Parser;
 use console::style;
 use jwt_simple::prelude::*;
@@ -28,6 +29,7 @@ impl ParseJwk {
                 let kp = ES384KeyPair::from_pem(pem.as_str()).expect("Invalid PEM");
                 kp.public_key().try_into_jwk().unwrap()
             }
+            JwsAlgorithm::P521 => return Err(anyhow!("P521 not supported")),
             JwsAlgorithm::Ed25519 => {
                 let kp = Ed25519KeyPair::from_pem(pem.as_str()).expect("Invalid PEM");
                 kp.public_key().try_into_jwk().unwrap()

--- a/e2e-identity/src/builder.rs
+++ b/e2e-identity/src/builder.rs
@@ -310,7 +310,7 @@ pub mod tests {
         };
         let (cert_chain, ..) = builder.build_x509();
         let cert = cert_chain.first().unwrap();
-        let identity = cert.extract_identity(None).unwrap();
+        let identity = cert.extract_identity(None, HashAlgorithm::SHA256).unwrap();
         assert_eq!(&identity.client_id, client_id);
         assert_eq!(
             identity.handle.as_str(),
@@ -325,6 +325,6 @@ pub mod tests {
     fn default_should_be_valid() {
         let (cert_chain, ..) = WireIdentityBuilder::default().build_x509();
         let cert = cert_chain.first().unwrap();
-        assert!(cert.extract_identity(None).is_ok());
+        assert!(cert.extract_identity(None, HashAlgorithm::SHA256).is_ok());
     }
 }

--- a/e2e-identity/src/error.rs
+++ b/e2e-identity/src/error.rs
@@ -19,4 +19,7 @@ pub enum E2eIdentityError {
     /// Core JWT error
     #[error(transparent)]
     JwtSimpleError(#[from] jwt_simple::Error),
+    /// Not supported
+    #[error("Not supported")]
+    NotSupported,
 }

--- a/e2e-identity/src/lib.rs
+++ b/e2e-identity/src/lib.rs
@@ -57,6 +57,7 @@ impl RustyE2eIdentity {
             JwsAlgorithm::Ed25519 => Ed25519KeyPair::from_bytes(&raw_sign_key[..])?.to_pem(),
             JwsAlgorithm::P256 => ES256KeyPair::from_bytes(&raw_sign_key[..])?.to_pem()?,
             JwsAlgorithm::P384 => ES384KeyPair::from_bytes(&raw_sign_key[..])?.to_pem()?,
+            JwsAlgorithm::P521 => return Err(E2eIdentityError::NotSupported),
         };
         let (acme_kp, acme_jwk) = match sign_alg {
             JwsAlgorithm::Ed25519 => {
@@ -71,6 +72,7 @@ impl RustyE2eIdentity {
                 let kp = ES384KeyPair::generate();
                 (kp.to_pem()?.into(), kp.public_key().try_into_jwk()?)
             }
+            JwsAlgorithm::P521 => return Err(E2eIdentityError::NotSupported),
         };
         // drop the private immediately since it already has been copied
         raw_sign_key.zeroize();
@@ -455,6 +457,6 @@ impl RustyE2eIdentity {
         env: Option<&PkiEnvironment>,
     ) -> E2eIdentityResult<Vec<Vec<u8>>> {
         let order = order.try_into()?;
-        Ok(RustyAcme::certificate_response(response, order, env)?)
+        Ok(RustyAcme::certificate_response(response, order, self.hash_alg, env)?)
     }
 }

--- a/e2e-identity/tests/utils/cfg.rs
+++ b/e2e-identity/tests/utils/cfg.rs
@@ -188,6 +188,7 @@ impl<'a> E2eTest<'a> {
                     acme_kp.public_key().try_into_jwk().unwrap(),
                 )
             }
+            JwsAlgorithm::P521 => unimplemented!(),
         };
 
         let hash_alg = HashAlgorithm::SHA256;

--- a/e2e-identity/tests/utils/fmk.rs
+++ b/e2e-identity/tests/utils/fmk.rs
@@ -958,7 +958,7 @@ impl<'a> E2eTest<'a> {
             .expect_header("content-type", "application/pem-certificate-chain");
         let resp = resp.text().await?;
         self.display_body(&resp);
-        let mut certificates = RustyAcme::certificate_response(resp, order, None)?;
+        let mut certificates = RustyAcme::certificate_response(resp, order, self.hash_alg, None)?;
         let root_ca = self.fetch_acme_root_ca().await;
         let root_ca_der = x509_cert::Certificate::from_pem(root_ca).unwrap().to_der().unwrap();
         certificates.push(root_ca_der);

--- a/jwt/Cargo.toml
+++ b/jwt/Cargo.toml
@@ -18,6 +18,7 @@ base64 = "0.21"
 uuid = { version = "1.6", features = ["v4"] }
 p256 = "0.13"
 p384 = "0.13"
+p521 = "0.13"
 sec1 = "0.7"
 url = { version = "2.5", features = ["serde"] }
 serde_json = "1.0"

--- a/jwt/src/access/verify.rs
+++ b/jwt/src/access/verify.rs
@@ -211,10 +211,7 @@ pub mod tests {
         #[apply(all_ciphersuites)]
         #[test]
         fn alg(ciphersuite: Ciphersuite) {
-            let unsupported = &[
-                "HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "PS256", "PS384", "PS512", "ES512",
-            ]
-            .map(|a| a.to_string());
+            let unsupported = JwsAlgorithm::UNSUPPORTED.map(|a| a.to_string());
             // should fail when 'alg' is not supported
             for alg in unsupported {
                 let access = AccessBuilder {

--- a/jwt/src/dpop/generate.rs
+++ b/jwt/src/dpop/generate.rs
@@ -146,6 +146,7 @@ pub mod tests {
                         let pk_pem = ES384PublicKey::try_from_jwk(jwk).unwrap().to_pem().unwrap();
                         (kty, curve, pk_pem)
                     }
+                    JwsEcAlgorithm::P521 => unimplemented!(),
                 };
                 p.key_type == kty && p.curve == curve && key.pk == jwk_pk.into()
             };
@@ -207,6 +208,7 @@ pub mod tests {
                 JwsEcAlgorithm::P384 => ES384PublicKey::from_pem(&key.pk)
                     .unwrap()
                     .verify_token::<Dpop>(&token, None),
+                JwsEcAlgorithm::P521 => unimplemented!(),
             };
             assert!(verify.is_ok());
 
@@ -214,6 +216,7 @@ pub mod tests {
             let verify_with_other_key = match key.alg {
                 JwsEcAlgorithm::P256 => ES256KeyPair::generate().public_key().verify_token::<Dpop>(&token, None),
                 JwsEcAlgorithm::P384 => ES384KeyPair::generate().public_key().verify_token::<Dpop>(&token, None),
+                JwsEcAlgorithm::P521 => unimplemented!(),
             };
             assert!(verify_with_other_key.is_err());
 
@@ -228,6 +231,7 @@ pub mod tests {
                     JwsEcAlgorithm::P384 => ES384PublicKey::try_from_jwk(j)
                         .unwrap()
                         .verify_token::<Dpop>(&token, None),
+                    JwsEcAlgorithm::P521 => unimplemented!(),
                 }
                 .is_ok()
             };

--- a/jwt/src/error.rs
+++ b/jwt/src/error.rs
@@ -104,8 +104,8 @@ pub enum RustyJwtError {
     /// DPoP token 'htm' claim mismatches with the expected method
     #[error("DPoP token 'htm' claim mismatches with the expected method")]
     DpopHtmMismatch,
-    /// DPoP proof has an unsupported algorithm
-    #[error("DPoP proof has an unsupported algorithm")]
+    /// Unsupported algorithm
+    #[error("Unsupported algorithm")]
     UnsupportedAlgorithm,
     /// Supplied backend keys have an invalid format
     #[error("Supplied backend keys have an invalid format because {0}")]

--- a/jwt/src/jwk/ecdsa.rs
+++ b/jwt/src/jwk/ecdsa.rs
@@ -73,6 +73,12 @@ impl TryIntoJwk for AnyEcPublicKey {
                 let y = RustyJwk::base64_url_encode(point.y().ok_or(RustyJwtError::ImplementationError)?);
                 (x, y)
             }
+            JwsEcAlgorithm::P521 => {
+                let point = p521::EncodedPoint::from_bytes(bytes)?;
+                let x = RustyJwk::base64_url_encode(point.x().ok_or(RustyJwtError::ImplementationError)?);
+                let y = RustyJwk::base64_url_encode(point.y().ok_or(RustyJwtError::ImplementationError)?);
+                (x, y)
+            }
         };
         Ok(Jwk {
             common: CommonParameters::default(),
@@ -117,6 +123,7 @@ pub mod tests {
                 };
                 assert!(matches!(jwk.algorithm, AlgorithmParameters::EllipticCurve(p) if is_valid(&p)));
             }
+            JwsEcAlgorithm::P521 => unimplemented!(),
         }
     }
 
@@ -136,6 +143,7 @@ pub mod tests {
                 let new_key = ES384PublicKey::try_from_jwk(&jwk).unwrap();
                 assert_eq!(original.to_bytes(), new_key.to_bytes());
             }
+            JwsEcAlgorithm::P521 => unimplemented!(),
         }
     }
 
@@ -156,6 +164,9 @@ pub mod tests {
                 // trying from the wrong key size
                 let result = ES256PublicKey::try_from_jwk(&jwk);
                 assert!(matches!(result.unwrap_err(), RustyJwtError::InvalidDpopJwk));
+            }
+            JwsEcAlgorithm::P521 => {
+                unimplemented!()
             }
         }
     }

--- a/jwt/src/jwk_thumbprint.rs
+++ b/jwt/src/jwk_thumbprint.rs
@@ -37,6 +37,12 @@ impl JwkThumbprint {
                 let hash = &hasher.finalize()[..];
                 base64::prelude::BASE64_URL_SAFE_NO_PAD.encode(hash)
             }
+            HashAlgorithm::SHA512 => {
+                let mut hasher = sha2::Sha512::new();
+                hasher.update(json);
+                let hash = &hasher.finalize()[..];
+                base64::prelude::BASE64_URL_SAFE_NO_PAD.encode(hash)
+            }
         };
         Ok(Self { kid })
     }
@@ -126,6 +132,10 @@ pub mod tests {
                     &thumbprint.kid,
                     "EcgQUf2ct-84eLYyH0o-leu6RJ46Lq_5jlCCEa5RlAPVcLXgHoh4Q0RnwFqRuk3y"
                 ),
+                HashAlgorithm::SHA512 => assert_eq!(
+                    &thumbprint.kid,
+                    "1Lc52f5GlYxMNFaQ5fXlBfU-Ho-mUVgMhTwVAagvWRrSHZTQiy4jdA2zV4K79AKXCs1yx8TqDKwULNc_7_Z0Ng"
+                ),
             }
         }
 
@@ -150,6 +160,10 @@ pub mod tests {
                 HashAlgorithm::SHA384 => assert_eq!(
                     &thumbprint.kid,
                     "tdNAT4Jr8cRlkxmgtYcum6EAGLWl6AXsflQs5izMSCY9gsFTD-cd5j1_vmev5_2X"
+                ),
+                HashAlgorithm::SHA512 => assert_eq!(
+                    &thumbprint.kid,
+                    "jDQEEK3aJ9Zq0KvJl-6mHfYuE_HiodVmY9Y--_h-QwXgkVk8Uwkhv9WavunCz8qhpQ8XKXHdDeqa-alWPaeqjQ"
                 ),
             }
         }
@@ -176,6 +190,10 @@ pub mod tests {
                     &thumbprint.kid,
                     "SDannkEbVekJlQtvocnp8oF38WVF23gEXj3tDqQnVlzJdinp2vgT-W-wbBN_wksO"
                 ),
+                HashAlgorithm::SHA512 => assert_eq!(
+                    &thumbprint.kid,
+                    "gIaQpxTXPJVE6XVzZRDG3AURbItjoEnxEVIJdICqXqtAzIAJJHvQNYxxKPZ6fvu4aEx-p7CvMimYkOtX0u4rLg"
+                ),
             }
         }
 
@@ -198,6 +216,10 @@ pub mod tests {
                 HashAlgorithm::SHA384 => assert_eq!(
                     &thumbprint.kid,
                     "Ow8bJ-FJVEMr6XcEDsio9IYfeq8OpvIgJnsE-7vQs2rdk_sWnp4gGjxMxAqcEjMy"
+                ),
+                HashAlgorithm::SHA512 => assert_eq!(
+                    &thumbprint.kid,
+                    "SiJgzsfOnllS44TLJ_qVl-oTGeh1eqtNDvnIiMxNhhD-CgRE1UwQVRlk_PIT9Y4xGqAWWm-o3goS79ery6vHmQ"
                 ),
             }
         }

--- a/jwt/src/jwt/generate.rs
+++ b/jwt/src/jwt/generate.rs
@@ -42,6 +42,7 @@ impl RustyJwtTools {
                 kp.attach_metadata(with_jwk(jwk))?;
                 Ok(kp.sign_with_header(claims, header)?)
             }
+            JwsAlgorithm::P521 => Err(RustyJwtError::UnsupportedAlgorithm),
         }
     }
 }

--- a/jwt/src/model/alg.rs
+++ b/jwt/src/model/alg.rs
@@ -20,6 +20,12 @@ pub enum JwsAlgorithm {
     ///
     /// [1]: https://tools.ietf.org/html/rfc7518#section-3.4
     P384,
+    /// ECDSA using P-521 and SHA-512
+    ///
+    /// Specified in [RFC 7518 Section 3.4: Digital Signature with ECDSA][1]
+    ///
+    /// [1]: https://tools.ietf.org/html/rfc7518#section-3.4
+    P521,
     /// EdDSA using Ed25519
     ///
     /// Specified in [RFC 8032: Edwards-Curve Digital Signature Algorithm (EdDSA)][1] and
@@ -35,6 +41,7 @@ impl ToString for JwsAlgorithm {
         match self {
             JwsAlgorithm::P256 => "ES256",
             JwsAlgorithm::P384 => "ES384",
+            JwsAlgorithm::P521 => "ES512",
             JwsAlgorithm::Ed25519 => "EdDSA",
         }
         .to_string()
@@ -48,6 +55,7 @@ impl TryFrom<&str> for JwsAlgorithm {
         Ok(match alg {
             "ES256" => JwsAlgorithm::P256,
             "ES384" => JwsAlgorithm::P384,
+            "ES512" => JwsAlgorithm::P521,
             "EdDSA" => JwsAlgorithm::Ed25519,
             _ => return Err(RustyJwtError::UnsupportedAlgorithm),
         })
@@ -57,8 +65,8 @@ impl TryFrom<&str> for JwsAlgorithm {
 #[cfg(test)]
 impl JwsAlgorithm {
     /// Utility for listing all the JWA signature schemes not supported by this crate
-    pub const UNSUPPORTED: [&'static str; 10] = [
-        "HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "PS256", "PS384", "PS512", "ES512",
+    pub const UNSUPPORTED: [&'static str; 9] = [
+        "HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "PS256", "PS384", "PS512",
     ];
 }
 
@@ -69,6 +77,8 @@ pub enum JwsEcAlgorithm {
     P256,
     /// P-384
     P384,
+    /// P-521
+    P521,
 }
 
 impl JwsEcAlgorithm {
@@ -77,6 +87,7 @@ impl JwsEcAlgorithm {
         match self {
             JwsEcAlgorithm::P256 => EllipticCurve::P256,
             JwsEcAlgorithm::P384 => EllipticCurve::P384,
+            JwsEcAlgorithm::P521 => EllipticCurve::P521,
         }
     }
 
@@ -93,6 +104,7 @@ impl TryFrom<JwsAlgorithm> for JwsEcAlgorithm {
         match alg {
             JwsAlgorithm::P256 => Ok(Self::P256),
             JwsAlgorithm::P384 => Ok(Self::P384),
+            JwsAlgorithm::P521 => Ok(Self::P521),
             JwsAlgorithm::Ed25519 => Err(RustyJwtError::ImplementationError),
         }
     }
@@ -103,6 +115,7 @@ impl From<JwsEcAlgorithm> for JwsAlgorithm {
         match alg {
             JwsEcAlgorithm::P256 => Self::P256,
             JwsEcAlgorithm::P384 => Self::P384,
+            JwsEcAlgorithm::P521 => Self::P521,
         }
     }
 }
@@ -134,7 +147,7 @@ impl TryFrom<JwsAlgorithm> for JwsEdAlgorithm {
     fn try_from(alg: JwsAlgorithm) -> RustyJwtResult<Self> {
         match alg {
             JwsAlgorithm::Ed25519 => Ok(Self::Ed25519),
-            JwsAlgorithm::P256 | JwsAlgorithm::P384 => Err(RustyJwtError::ImplementationError),
+            JwsAlgorithm::P256 | JwsAlgorithm::P384 | JwsAlgorithm::P521 => Err(RustyJwtError::ImplementationError),
         }
     }
 }
@@ -154,12 +167,14 @@ pub enum HashAlgorithm {
     SHA256,
     /// SHA-384
     SHA384,
+    /// SHA-512
+    SHA512,
 }
 
 #[cfg(test)]
 impl HashAlgorithm {
-    pub fn values() -> [Self; 2] {
-        [Self::SHA256, Self::SHA384]
+    pub fn values() -> [Self; 3] {
+        [Self::SHA256, Self::SHA384, Self::SHA512]
     }
 }
 
@@ -168,6 +183,7 @@ impl std::fmt::Display for HashAlgorithm {
         let name = match self {
             HashAlgorithm::SHA256 => "SHA-256",
             HashAlgorithm::SHA384 => "SHA-384",
+            HashAlgorithm::SHA512 => "SHA-512",
         };
         write!(f, "{name}")
     }
@@ -180,6 +196,7 @@ impl FromStr for HashAlgorithm {
         Ok(match s {
             "SHA-256" => Self::SHA256,
             "SHA-384" => Self::SHA384,
+            "SHA-512" => Self::SHA512,
             _ => return Err(RustyJwtError::ImplementationError),
         })
     }
@@ -191,6 +208,7 @@ impl From<JwsAlgorithm> for HashAlgorithm {
         match alg {
             JwsAlgorithm::Ed25519 | JwsAlgorithm::P256 => Self::SHA256,
             JwsAlgorithm::P384 => Self::SHA384,
+            JwsAlgorithm::P521 => Self::SHA512,
         }
     }
 }

--- a/jwt/src/test_utils/access.rs
+++ b/jwt/src/test_utils/access.rs
@@ -83,6 +83,7 @@ impl AccessBuilder {
                 .unwrap()
                 .sign_with_header(Some(self.claims()), self.header())
                 .unwrap(),
+            JwsAlgorithm::P521 => unimplemented!(),
             JwsAlgorithm::Ed25519 => Ed25519KeyPair::from_pem(kp)
                 .unwrap()
                 .sign_with_header(Some(self.claims()), self.header())

--- a/jwt/src/test_utils/dpop.rs
+++ b/jwt/src/test_utils/dpop.rs
@@ -83,6 +83,7 @@ impl DpopBuilder {
                 .unwrap()
                 .sign_with_header(Some(self.claims()), self.header())
                 .unwrap(),
+            JwsAlgorithm::P521 => unimplemented!(),
             JwsAlgorithm::Ed25519 => Ed25519KeyPair::from_pem(kp)
                 .unwrap()
                 .sign_with_header(Some(self.claims()), self.header())

--- a/jwt/src/test_utils/jwk.rs
+++ b/jwt/src/test_utils/jwk.rs
@@ -8,6 +8,7 @@ impl RustyJwk {
         match alg {
             JwsAlgorithm::P256 => ES256KeyPair::generate().public_key().try_into_jwk().unwrap(),
             JwsAlgorithm::P384 => ES384KeyPair::generate().public_key().try_into_jwk().unwrap(),
+            JwsAlgorithm::P521 => unimplemented!(),
             JwsAlgorithm::Ed25519 => Ed25519KeyPair::generate().public_key().try_into_jwk().unwrap(),
         }
     }

--- a/jwt/tests/e2e.rs
+++ b/jwt/tests/e2e.rs
@@ -78,6 +78,7 @@ fn e2e_jwt() {
                 .public_key()
                 .to_pem()
                 .unwrap(),
+            JwsAlgorithm::P521 => unimplemented!(),
             JwsAlgorithm::Ed25519 => Ed25519KeyPair::from_pem(backend_keys.as_str())
                 .unwrap()
                 .public_key()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
