### PR TITLE
fix: JWK thumbprint was failing for NIST P-curves

### DIFF
--- a/acme/src/error.rs
+++ b/acme/src/error.rs
@@ -22,6 +22,9 @@ pub enum RustyAcmeError {
     /// Failed mapping a DER certificate
     #[error(transparent)]
     DerError(#[from] x509_cert::der::Error),
+    /// Failed with DER conversion
+    #[error(transparent)]
+    Asn1DerError(#[from] asn1_rs::Err<asn1_rs::Error>),
     /// Failed mapping a DER object
     #[error(transparent)]
     Asn1SerializeError(#[from] asn1_rs::SerializeError),
@@ -102,4 +105,7 @@ pub enum CertificateError {
     /// Advertised public key does not match algorithm
     #[error("Advertised public key does not match algorithm")]
     InvalidPublicKey,
+    /// Advertised public key is not supported
+    #[error("Advertised public key is not supported")]
+    UnsupportedPublicKey,
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Expected OID was a signature one and not a public key one

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
