### PR TITLE
fix: failing haskell ffi test due to expired dpop proof WPB-11219

### DIFF
--- a/ffi/bindings/haskell/test/Spec.hs
+++ b/ffi/bindings/haskell/test/Spec.hs
@@ -52,17 +52,16 @@ main = hspec $ do
                    \3r4zMK0hEXT7i+xR3PyGfrPHcqahRANCAAQ84mdGFohHioIhOG/s8S2mHNXiKzdV\n\
                    \ZTvpq663q4ErPGj7OP0P7Ef1QrXvHmTDOTx5YwUJ3OAxDXDOdSkD0zPt\n\
                    \-----END PRIVATE KEY-----"
-    clientId = 14730821443162901434
+    clientId = 1223
     domain = "example.com"
-    url = "https://example.com/clients/cc6e640e296e8bba/access-token"
+    url = "https://wire.example.com/client/token"
     method = "POST"
     maxSkewSeconds = 1
     now = 1704982162
-
-    proof = "eyJhbGciOiJFUzI1NiIsInR5cCI6ImRwb3Arand0IiwiandrIjp7Imt0eSI6IkVDIiwiY3J2IjoiUC0yNTYiLCJ4IjoiUE9KblJoYUlSNHFDSVRodjdQRXRwaHpWNGlzM1ZXVTc2YXV1dDZ1Qkt6dyIsInkiOiJhUHM0X1Ffc1JfVkN0ZThlWk1NNVBIbGpCUW5jNERFTmNNNTFLUVBUTS0wIn19.eyJpYXQiOjE3MjU5NTY1MjUsImV4cCI6MTcyNjA0NjUyNSwibmJmIjoxNzI1OTU2NTI1LCJzdWIiOiJ3aXJlYXBwOi8vTkdyekQ2T0NRYmlwdWpHOS1UVXU2dyFjYzZlNjQwZTI5NmU4YmJhQGV4YW1wbGUuY29tIiwiYXVkIjoiaHR0cHM6Ly9zdGVwY2EvYWNtZS93aXJlL2NoYWxsZW5nZS9hYWEvYmJiIiwianRpIjoiMmQwNDMyOTMtNDg5My00NDU3LTk4NTAtZGUwOGQ0NDg2Njg2Iiwibm9uY2UiOiI0M0ZDSWMwVVFqaU5tdlBPSHoyenl3IiwiaHRtIjoiUE9TVCIsImh0dSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vY2xpZW50cy9jYzZlNjQwZTI5NmU4YmJhL2FjY2Vzcy10b2tlbiIsImNoYWwiOiI0M0ZDSWMwVVFqaU5tdlBPSHoyenl3IiwiaGFuZGxlIjoid2lyZWFwcDovLyU0MGtjdmVwY2tieWZ5eWV4anNwc3pjeEBleGFtcGxlLmNvbSIsInRlYW0iOiI2ZTg1ZTA1My01MzZmLTQ1ODUtOGZjOC1jYWRhODc2ZTVlYzciLCJuYW1lIjoiam9lIn0.YJydGqugbKKq_IBdphLVVwJmyEg2ESItEZtqZu6AWprl5KFSZo7knbRDw2AGSREobBFElis8uaHqXo18w5htkg"
-    uid = fromMaybe (error "invalid user id") $ UUID.fromString "346af30f-a382-41b8-a9ba-31bdf9352eeb"
-    nonce = "43FCIc0UQjiNmvPOHz2zyw"
-    expiration = 1881935509
-    handle = "kcvepckbyfyyexjspszcx"
-    displayName = "joe"
+    proof = "eyJhbGciOiJFUzI1NiIsInR5cCI6ImRwb3Arand0IiwiandrIjp7Imt0eSI6IkVDIiwiY3J2IjoiUC0yNTYiLCJ4IjoiLUE2T3ZqNFVzRmFrbFZMUHZhZDhYNF80MXRBTW55ZnR3aGVXbnNSMzVvbyIsInkiOiI3S3E3UzQxUjh4NUVzTnVjY1J4Y3ItcjN2SWhYVmloR3BLUFAweThIczBvIn19.eyJpYXQiOjE3MjcyMTI5NDIsImV4cCI6MjA0MjU3NjU0MiwibmJmIjoxNzI3MjEyOTQyLCJzdWIiOiJ3aXJlYXBwOi8vU3ZQZkxsd0JRaS02b2RkVlJya3FwdyE0YzdAZXhhbXBsZS5jb20iLCJhdWQiOiJodHRwczovL3N0ZXBjYS9hY21lL3dpcmUvY2hhbGxlbmdlL2FhYS9iYmIiLCJqdGkiOiJlNzg1MGYxNy1jYzc3LTQ0ZmYtYThiNi0wODMyYjA1NTdkNmUiLCJub25jZSI6IldFODhFdk9CemJxR2Vyem5NKzJQL0FhZFZmNzM3NHkwY0gxOXNEU1pBMkEiLCJodG0iOiJQT1NUIiwiaHR1IjoiaHR0cHM6Ly93aXJlLmV4YW1wbGUuY29tL2NsaWVudC90b2tlbiIsImNoYWwiOiJva0FKMzNZbS9YUzJxbW1oaGg3YVdTYkJsWXk0VHRtMUV5c3FXOEkvOW5nIiwiaGFuZGxlIjoid2lyZWFwcDovLyU0MGpvaG5fZG9lQGV4YW1wbGUuY29tIiwidGVhbSI6IjZlODVlMDUzLTUzNmYtNDU4NS04ZmM4LWNhZGE4NzZlNWVjNyIsIm5hbWUiOiJKb2huIERvZSJ9.M7Zc0FIHazWbWg6PeFK1DVJoLiLeqx09Y9KQSLPgrp5DzGnvj2Gxo4z0ELwzpIUv9pfuw4f-tImRQSS7_RKmww"
+    uid = fromMaybe (error "invalid user id") $ UUID.fromString "4af3df2e-5c01-422f-baa1-d75546b92aa7"
+    nonce = "WE88EvOBzbqGerznM+2P/AadVf7374y0cH19sDSZA2A"
+    expiration = 2042742401
+    handle = "john_doe"
+    displayName = "John Doe"
     teamId = fromMaybe (error "invalid team id") $ UUID.fromString "6e85e053-536f-4585-8fc8-cada876e5ec7"


### PR DESCRIPTION
# What's new in this PR

The Haskell FFI tests are failing since the DPoP Proof has expired. I've generated a new DPoP proof which is valid for 10 years.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
