### PR TITLE
chore: update keycloak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,10 +1598,12 @@ dependencies = [
 
 [[package]]
 name = "keycloak"
-version = "25.0.200"
-source = "git+https://github.com/wireapp/keycloak?branch=wire/25.0.2-fix-type-issues#da2cec6c0e4df1cf1d786ade2f960aa6adf66eff"
+version = "26.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c304d1798561b0778d71d4d55e24a15688d24f17e0b36ecb269f30da846dcf84"
 dependencies = [
  "async-trait",
+ "percent-encoding",
  "reqwest 0.12.8",
  "serde",
  "serde_json",
@@ -2833,7 +2835,7 @@ dependencies = [
 
 [[package]]
 name = "rusty-acme"
-version = "0.9.0"
+version = "0.11.0"
 dependencies = [
  "base64 0.22.1",
  "const-oid",
@@ -2861,7 +2863,7 @@ dependencies = [
 
 [[package]]
 name = "rusty-jwt-tools"
-version = "0.9.0"
+version = "0.11.0"
 dependencies = [
  "base64 0.22.1",
  "biscuit",
@@ -2898,7 +2900,7 @@ dependencies = [
 
 [[package]]
 name = "rusty-jwt-tools-ffi"
-version = "0.9.0"
+version = "0.11.0"
 dependencies = [
  "rusty-jwt-tools",
  "uuid",
@@ -2906,7 +2908,7 @@ dependencies = [
 
 [[package]]
 name = "rusty-x509-check"
-version = "0.9.0"
+version = "0.11.0"
 dependencies = [
  "certval",
  "const-oid",
@@ -4163,7 +4165,7 @@ dependencies = [
 
 [[package]]
 name = "wire-e2e-identity"
-version = "0.9.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,5 +60,5 @@ testcontainers = { version = "0.23", default-features = false }
 oauth2 = { version = "4.3", default-features = false }
 http = { version = "1", default-features = false }
 # Keep keycloak versions in sync (search for this comment to find all places to update)
-keycloak = { git = "https://github.com/wireapp/keycloak", branch = "wire/25.0.2-fix-type-issues" }
+keycloak = "26.0.1"
 rand_chacha = { version = "0.3", default-features = false }

--- a/e2e-identity/tests/utils/docker/keycloak.rs
+++ b/e2e-identity/tests/utils/docker/keycloak.rs
@@ -35,7 +35,7 @@ impl KeycloakImage {
     const NAME: &'static str = "wire-keycloak";
     const TAG: &'static str = "latest";
     // Keep keycloak versions in sync (search for this comment to find all places to update)
-    const VERSION: &'static str = "25.0.2";
+    const VERSION: &'static str = "26.0.1";
 
     pub const USER: &'static str = "admin";
     pub const PASSWORD: &'static str = "changeme";

--- a/e2e-identity/tests/utils/docker/keycloak/Dockerfile
+++ b/e2e-identity/tests/utils/docker/keycloak/Dockerfile
@@ -1,5 +1,5 @@
 # Keep keycloak versions in sync (search for this comment to find all places to update)
-FROM quay.io/keycloak/keycloak:25.0.2  
+FROM quay.io/keycloak/keycloak:26.0.1  
 ARG kc_port
 
 WORKDIR /opt/keycloak


### PR DESCRIPTION
Since kilork/keycloak#130 was fixed, we can drop the fork.

# What's new in this PR
See above

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
