### PR TITLE
test: e2e-identity: increase the validity period of the intermediat CA cert

### DIFF
--- a/e2e-identity/tests/utils/docker/stepca.rs
+++ b/e2e-identity/tests/utils/docker/stepca.rs
@@ -198,7 +198,7 @@ pub async fn start_acme_server(ca_cfg: &CaCfg) -> AcmeServer {
     run_command(
         &node,
         "step certificate create 'Wire Intermediate CA' intermediate-ca.crt intermediate-ca.key
-                            --template intermediate.template --password-file password
+                            --template intermediate.template --password-file password --not-after 87600h
                             --ca root-ca.crt --ca-key root-ca.key --ca-password-file password",
     )
     .await;


### PR DESCRIPTION
By default it's 24h, which is relatively short if one tries to use these certs for debugging. Increase it to 10 years to make it the same as the validity period of root CA cert and the leaf cert.

