### PR TITLE
chore: ci: pin ghc to 9.2

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,6 +73,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: haskell-actions/setup@v2
+        with:
+            ghc-version: '9.2'
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           rustflags: ''


### PR DESCRIPTION
Should fix this Cabal warning:

    Warning: Unknown/unsupported 'ghc' version detected (Cabal 3.14.1.0 supports
    'ghc' version < 9.12): /home/runner/.ghcup/bin/ghc is version 9.12.1

and hopefully the build error.
