### PR TITLE
chore: ci: fetch the tag manually

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,6 +35,7 @@ jobs:
       - name: ensure tags are signed
         run: |
           if [[ ${{ github.ref_type }} == tag ]]; then
+            git fetch -f origin ${{ github.ref }}:${{ github.ref }}
             git cat-file tag ${{ github.ref_name }} | grep -q -- '-----BEGIN PGP SIGNATURE-----'
           fi
       - uses: actions-rust-lang/setup-rust-toolchain@v1


### PR DESCRIPTION
Since actions/checkout is broken
(see https://github.com/actions/checkout/issues/290), we need to manually fetch tag objects to check for signatures.
