### PR TITLE
doc: ensure safety notes for unsafe blocks [WPB-10887]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 members = ["e2e-identity", "jwt", "ffi", "acme", "x509-check"]
 resolver = "2"
 
+[workspace.lints.clippy]
+missing_safety_doc = "deny"
+undocumented_unsafe_blocks = "deny"
+
 [workspace.dependencies]
 anyhow = { version = "1.0", default-features = false }
 base64 = { version = "0.22", default-features = false, features = ["std"] }

--- a/acme/Cargo.toml
+++ b/acme/Cargo.toml
@@ -10,6 +10,9 @@ publish = false
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[lints]
+workspace = true
+
 [dependencies]
 rusty-jwt-tools = { version = "0.12.0", path = "../jwt" }
 rusty-x509-check = { version = "0.12.0", path = "../x509-check" }

--- a/e2e-identity/Cargo.toml
+++ b/e2e-identity/Cargo.toml
@@ -10,6 +10,9 @@ publish = false
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[lints]
+workspace = true
+
 [dependencies]
 rusty-acme = { version = "0.12.0", path = "../acme" }
 rusty-jwt-tools = { version = "0.12.0", path = "../jwt" }

--- a/e2e-identity/tests/utils/cfg.rs
+++ b/e2e-identity/tests/utils/cfg.rs
@@ -69,10 +69,6 @@ pub enum OidcProvider {
     Google,
 }
 
-unsafe impl Send for E2eTest {}
-
-unsafe impl Sync for E2eTest {}
-
 impl E2eTest {
     const STEPCA_HOST: &'static str = "stepca";
     const LDAP_HOST: &'static str = "ldap";

--- a/e2e-identity/tests/utils/fmk.rs
+++ b/e2e-identity/tests/utils/fmk.rs
@@ -768,6 +768,7 @@ impl E2eTest {
     }
 
     pub async fn fetch_id_token_from_google(&mut self) -> TestResult<String> {
+        // SAFETY: safe because there is one codepath using these variables and we are just unconditionally setting them here.
         unsafe {
             let (tx, rx) = std::sync::mpsc::channel();
             GOOGLE_SND = Some(std::sync::Mutex::new(tx));
@@ -810,6 +811,8 @@ impl E2eTest {
             .url();
         webbrowser::open(authz_url.as_str()).unwrap();
 
+        // SAFETY: We initialized the reference earlier in this function, and the worst case if
+        // someone has mutated it under us is that one of the unwraps causes a test to panic.
         let id_token = unsafe {
             let rx = GOOGLE_RECV.as_ref().unwrap().lock().unwrap();
             rx.recv().unwrap()

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -11,6 +11,9 @@ publish = false
 name = "rusty_jwt_tools_ffi"
 crate-type = ["cdylib", "staticlib"]
 
+[lints]
+workspace = true
+
 [dependencies]
 rusty-jwt-tools = { version = "0.12.0", path = "../jwt" }
 uuid = { workspace = true }

--- a/jwt/Cargo.toml
+++ b/jwt/Cargo.toml
@@ -11,6 +11,9 @@ publish = false
 name = "rusty_jwt_tools"
 crate-type = ["cdylib", "rlib"]
 
+[lints]
+workspace = true
+
 [dependencies]
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/x509-check/Cargo.toml
+++ b/x509-check/Cargo.toml
@@ -7,6 +7,9 @@ repository = "https://github.com/wireapp/rusty-jwt-tools"
 license = "MPL-2.0"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 web-time = { workspace = true }
 flagset = { workspace = true }


### PR DESCRIPTION
# What's new in this PR

- add safety notes to unsafe blocks
- enable clippy rules denying future missing undocumented unsafe blocks and functions

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
