### PR TITLE
test: e2e-identity: add a marker on nominal_enrollment [WPB-17039]

### DIFF
--- a/e2e-identity/tests/utils/fmk.rs
+++ b/e2e-identity/tests/utils/fmk.rs
@@ -83,6 +83,7 @@ fn jws_algorithm_to_x509_oids(alg: JwsAlgorithm) -> (ObjectIdentifier, Option<Ob
 }
 
 impl E2eTest {
+    // @SF.PROVISIONING @TSFI.E2EI-PKI-Admin @S8
     pub async fn nominal_enrollment(self) -> TestResult<Self> {
         self.enrollment(EnrollmentFlow::default()).await
     }


### PR DESCRIPTION
It's the main entry point to the whole default enrollment process.
