### PR TITLE
chore: add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.86"


### PR DESCRIPTION
This is to make our builds & CI reproducible in the future. Currently if we go to one of the release branches, we need to hunt for the proper toolchain version in order to pass CI successfully.
