### PR TITLE
test: rename SF.PROVISIONING to SF.Provisioning

### DIFF
--- a/e2e-identity/tests/e2e.rs
+++ b/e2e-identity/tests/e2e.rs
@@ -68,7 +68,7 @@ mod alg {
     // - a check that all certificates in the chain parse successfully
     // - a check that invokes `openssl verify` to verify the entire certificate chain
     //
-    // @SF.PROVISIONING @TSFI.E2EI-PKI-Admin @S8
+    // @SF.Provisioning @TSFI.E2EI-PKI-Admin @S8
     #[tokio::test]
     async fn ed25519_should_succeed() {
         let test = E2eTest::new_internal(false, JwsAlgorithm::Ed25519, OidcProvider::Keycloak)
@@ -77,7 +77,7 @@ mod alg {
         assert!(test.nominal_enrollment().await.is_ok());
     }
 
-    // @SF.PROVISIONING @TSFI.E2EI-PKI-Admin @S8
+    // @SF.Provisioning @TSFI.E2EI-PKI-Admin @S8
     #[tokio::test]
     async fn p256_should_succeed() {
         let test = E2eTest::new_internal(false, JwsAlgorithm::P256, OidcProvider::Keycloak)
@@ -86,7 +86,7 @@ mod alg {
         assert!(test.nominal_enrollment().await.is_ok());
     }
 
-    // @SF.PROVISIONING @TSFI.E2EI-PKI-Admin @S8
+    // @SF.Provisioning @TSFI.E2EI-PKI-Admin @S8
     #[tokio::test]
     async fn p384_should_succeed() {
         let test = E2eTest::new_internal(false, JwsAlgorithm::P384, OidcProvider::Keycloak)
@@ -95,7 +95,7 @@ mod alg {
         assert!(test.nominal_enrollment().await.is_ok());
     }
 
-    // @SF.PROVISIONING @TSFI.E2EI-PKI-Admin @S8
+    // @SF.Provisioning @TSFI.E2EI-PKI-Admin @S8
     #[tokio::test]
     async fn p521_should_succeed() {
         let test = E2eTest::new_internal(false, JwsAlgorithm::P521, OidcProvider::Keycloak)
@@ -116,7 +116,7 @@ mod acme_server {
 
     #[tokio::test]
     /// Acme server has been man-in-middle:ed and returns untrusted certificates
-    // @SF.PROVISIONING @TSFI.ACME
+    // @SF.Provisioning @TSFI.ACME
     async fn should_fail_when_certificate_path_doesnt_contain_trust_anchor() {
         let test = E2eTest::new().start().await;
 
@@ -164,7 +164,7 @@ mod acme_server {
 
     #[tokio::test]
     /// Challenges returned by ACME server are mixed up
-    // @SF.PROVISIONING @TSFI.ACME
+    // @SF.Provisioning @TSFI.ACME
     async fn should_fail_when_no_replay_nonce_requested() {
         let test = E2eTest::new().start().await;
 
@@ -186,7 +186,7 @@ mod acme_server {
 
     #[tokio::test]
     /// Replay nonce is reused by the client
-    // @SF.PROVISIONING @TSFI.ACME
+    // @SF.Provisioning @TSFI.ACME
     async fn should_fail_when_replay_nonce_reused() {
         let test = E2eTest::new().start().await;
 
@@ -213,7 +213,7 @@ mod acme_server {
     /// request payloads must be signed by the same client key which created the acme account.
     #[tokio::test]
     /// This verifies the DPoP challenge verification method on the acme server
-    // @SF.PROVISIONING @TSFI.ACME
+    // @SF.Provisioning @TSFI.ACME
     async fn should_fail_when_dpop_challenge_signed_by_a_different_key() {
         let test = E2eTest::new().start().await;
 
@@ -242,7 +242,7 @@ mod acme_server {
     /// request payloads must be signed by the same client key which created the acme account.
     #[tokio::test]
     /// This verifies the DPoP challenge verification method on the acme server
-    // @SF.PROVISIONING @TSFI.ACME
+    // @SF.Provisioning @TSFI.ACME
     async fn should_fail_when_oidc_challenge_signed_by_a_different_key() {
         let test = E2eTest::new().start().await;
 
@@ -274,7 +274,7 @@ mod dpop_challenge {
     #[tokio::test]
     /// Demonstrates that the client possesses the clientId. Client makes an authenticated request
     /// to wire-server, it delivers a nonce which the client seals in a signed DPoP JWT.
-    // @SF.PROVISIONING @TSFI.ACME @S8
+    // @SF.Provisioning @TSFI.ACME @S8
     async fn should_fail_when_client_dpop_token_has_wrong_backend_nonce() {
         let test = E2eTest::new().start().await;
 
@@ -304,7 +304,7 @@ mod dpop_challenge {
     #[tokio::test]
     /// Acme server should be configured with wire-server public key to verify the access tokens
     /// issued by wire-server.
-    // @SF.PROVISIONING @TSFI.ACME @S8
+    // @SF.Provisioning @TSFI.ACME @S8
     async fn should_fail_when_access_token_not_signed_by_wire_server() {
         let default = E2eTest::new();
         let wrong_backend_kp = Ed25519KeyPair::generate();
@@ -324,7 +324,7 @@ mod dpop_challenge {
 
     #[tokio::test]
     /// The access token has a 'chal' claim which should match the Acme challenge 'token'. This is verified by the acme server
-    // @SF.PROVISIONING @TSFI.ACME @S8
+    // @SF.Provisioning @TSFI.ACME @S8
     async fn should_fail_when_access_token_challenge_claim_is_not_current_challenge_one() {
         let test = E2eTest::new().start().await;
 
@@ -356,7 +356,7 @@ mod dpop_challenge {
     /// We first set a clientId for the enrollment process when we create the acme order. This same
     /// clientId must be used and sealed in the accessToken which is verified by the acme server in
     /// the oidc challenge. The challenge should be invalid if they differ
-    // @SF.PROVISIONING @TSFI.ACME @S8
+    // @SF.Provisioning @TSFI.ACME @S8
     async fn should_fail_when_access_token_client_id_mismatches() {
         let test = E2eTest::new().start().await;
 
@@ -387,7 +387,7 @@ mod dpop_challenge {
     #[tokio::test]
     /// Client DPoP token is nested within access token. The former should not be expired when
     /// acme server verifies the DPoP challenge
-    // @SF.PROVISIONING @TSFI.ACME @S8
+    // @SF.Provisioning @TSFI.ACME @S8
     async fn should_fail_when_expired_client_dpop_token() {
         let test = E2eTest::new().start().await;
 
@@ -415,7 +415,7 @@ mod dpop_challenge {
     /// with the accepted wire-server host which is present in the DPoP "htu" claim and in the access token
     /// "iss" claim.
     /// The challenge should fail if any of those does not match the expected value
-    // @SF.PROVISIONING @TSFI.ACME @S8
+    // @SF.Provisioning @TSFI.ACME @S8
     async fn should_fail_when_access_token_iss_mismatches_target() {
         // "iss" in access token mismatches expected target
         let test = E2eTest::new().start().await;
@@ -495,7 +495,7 @@ mod dpop_challenge {
 
     #[tokio::test]
     /// see [should_fail_when_access_token_iss_mismatches_target]
-    // @SF.PROVISIONING @TSFI.ACME @S8
+    // @SF.Provisioning @TSFI.ACME @S8
     async fn should_fail_when_access_token_device_id_mismatches_target() {
         // "iss" deviceId mismatches the actual deviceId
         let test = E2eTest::new().start().await;
@@ -582,7 +582,7 @@ mod dpop_challenge {
     /// then verified and sealed in the access token which is finally verified by the ACME server
     /// as part of the DPoP challenge.
     /// Here we make the acme-server fail.
-    // @SF.PROVISIONING @TSFI.ACME @S8
+    // @SF.Provisioning @TSFI.ACME @S8
     async fn acme_should_fail_when_client_dpop_token_has_wrong_handle() {
         let test = E2eTest::new().start().await;
 
@@ -612,7 +612,7 @@ mod dpop_challenge {
     /// In this attack, a malicious server forges an access token with a forged proof (the client DPoP token). Since it
     /// does not know the keypair used by the client it will use a random one. This should fail since the acme-server
     /// will verify the 'cnf.kid' and verify that it is indeed the JWK thumbprint of the ACME client.
-    // @SF.PROVISIONING @TSFI.ACME @S8
+    // @SF.Provisioning @TSFI.ACME @S8
     async fn acme_should_fail_when_client_dpop_token_has_wrong_kid() {
         let test = E2eTest::new().start().await;
 
@@ -693,7 +693,7 @@ mod dpop_challenge {
 
     #[tokio::test]
     /// We bind the DPoP challenge "uri" to the access token. It is then validated by the ACME server
-    // @SF.PROVISIONING @TSFI.ACME @S8
+    // @SF.Provisioning @TSFI.ACME @S8
     async fn should_fail_when_invalid_dpop_audience() {
         let test = E2eTest::new().start().await;
         let flow = EnrollmentFlow {
@@ -724,7 +724,7 @@ mod dpop_challenge {
     #[tokio::test]
     /// The DPoP token holds the "display name" of the client which is compared by the acme server against the
     /// display name in the acme identifier as part of the acme order
-    // @SF.PROVISIONING @TSFI.ACME @S8
+    // @SF.Provisioning @TSFI.ACME @S8
     async fn acme_should_fail_when_client_dpop_token_has_wrong_display_name() {
         let test = E2eTest::new().start().await;
 
@@ -770,7 +770,7 @@ mod oidc_challenge {
     /// Authorization Server exposes an endpoint for clients to fetch its public
     /// keys (it gets from the OAuth discovery endpoint of hte IdP).
     /// It is used to validate the signature of the id token we supply to this challenge.
-    // @SF.PROVISIONING @TSFI.ACME @S8
+    // @SF.Provisioning @TSFI.ACME @S8
     async fn should_fail_when_oidc_provider_discovery_uri_unavailable() {
         let mut test = E2eTest::new();
         // invalid discovery uri
@@ -790,7 +790,7 @@ mod oidc_challenge {
     #[ignore] // FIXME: adapt with Keycloak
     /// An id token with an invalid name is supplied to ACME server. It should verify that the handle
     /// is the same as the one used in the order.
-    // @SF.PROVISIONING @TSFI.ACME @S8
+    // @SF.Provisioning @TSFI.ACME @S8
     async fn should_fail_when_invalid_handle() {
         let test = E2eTest::new();
 
@@ -832,7 +832,7 @@ mod oidc_challenge {
     #[ignore] // FIXME: adapt with Keycloak
     /// An id token with an invalid name is supplied to ACME server. It should verify that the display name
     /// is the same as the one used in the order.
-    // @SF.PROVISIONING @TSFI.ACME @S8
+    // @SF.Provisioning @TSFI.ACME @S8
     async fn should_fail_when_invalid_display_name() {
         let test = E2eTest::new();
 
@@ -874,7 +874,7 @@ mod oidc_challenge {
     /// We use the "keyauth": '{oidc-challenge-token}.{acme-key-thumbprint}' to bind the acme client to the id token
     /// we validate in the acme server. This prevents id token being stolen or OAuth authorization performed outside of
     /// the current ACME session.
-    // @SF.PROVISIONING @TSFI.ACME @S8
+    // @SF.Provisioning @TSFI.ACME @S8
     async fn should_fail_when_invalid_keyauth() {
         let test = E2eTest::new().start().await;
         let flow = EnrollmentFlow {
@@ -895,7 +895,7 @@ mod oidc_challenge {
 
     #[tokio::test]
     /// We add an "acme_aud" in the idToken which must match the OIDC challenge url
-    // @SF.PROVISIONING @TSFI.ACME @S8
+    // @SF.Provisioning @TSFI.ACME @S8
     async fn should_fail_when_invalid_audience() {
         let test = E2eTest::new().start().await;
         let flow = EnrollmentFlow {


### PR DESCRIPTION
# What's new in this PR
Renames the SF.PROVISIONING tag to SF.Provisioning as requested in [WPB-18700](https://wearezeta.atlassian.net/browse/WPB-18700) 
----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.


[WPB-18700]: https://wearezeta.atlassian.net/browse/WPB-18700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ