### PR TITLE
test: e2e-identity: drop "login" endpoint of the test Wire server

### DIFF
--- a/e2e-identity/tests/utils/wire_server/mod.rs
+++ b/e2e-identity/tests/utils/wire_server/mod.rs
@@ -1,7 +1,6 @@
 pub mod oidc;
 pub mod server_api;
 
-use crate::utils::ctx::{ctx_get, ctx_store};
 use hyper::server::conn::http1;
 use hyper_util::rt::TokioIo;
 use std::net::SocketAddr;
@@ -14,28 +13,6 @@ pub struct OauthCfg {
     pub client_id: String,
     pub client_secret: String,
     pub redirect_uri: String,
-}
-
-impl OauthCfg {
-    pub fn cxt_store(&self) {
-        ctx_store("issuer-uri", self.issuer_uri.clone());
-        ctx_store("client-id", self.client_id.clone());
-        ctx_store("client-secret", self.client_secret.clone());
-        ctx_store("redirect-uri", self.redirect_uri.clone());
-    }
-
-    pub fn cxt_get() -> Self {
-        let issuer_uri = ctx_get("issuer-uri").unwrap();
-        let client_id = ctx_get("client-id").unwrap();
-        let client_secret = ctx_get("client-secret").unwrap();
-        let redirect_uri = ctx_get("redirect-uri").unwrap();
-        Self {
-            issuer_uri,
-            client_id,
-            client_secret,
-            redirect_uri,
-        }
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/e2e-identity/tests/utils/wire_server/server_api.rs
+++ b/e2e-identity/tests/utils/wire_server/server_api.rs
@@ -4,11 +4,7 @@ use hyper::body::{Bytes, Incoming};
 use hyper::{Method, Request, Response, StatusCode};
 use rusty_jwt_tools::prelude::*;
 
-use crate::utils::{
-    ctx::ctx_get,
-    rand_base64_str,
-    wire_server::oidc::{handle_callback, handle_login},
-};
+use crate::utils::{ctx::ctx_get, rand_base64_str, wire_server::oidc::handle_callback};
 
 // simulates wire-server database
 static mut PREVIOUS_NONCE: &str = "";
@@ -58,7 +54,6 @@ pub async fn wire_api(req: Request<Incoming>) -> http::Result<Response<Full<Byte
             let body = serde_json::to_vec(&body).unwrap().into();
             Response::builder().status(StatusCode::OK).body(body).unwrap()
         }
-        (&Method::GET, ["login"]) => handle_login(req).await?,
         (&Method::GET, ["callback"]) => handle_callback(req).await?,
         _ => not_found()?,
     })


### PR DESCRIPTION
The endpoint is not used at all and it also does not make sense to test it because it is out of scope of E2EI (it is assumed that the client is already logged in and has proper authorization to request the nonce from Wire server).
