### PR TITLE
chore: do not ignore a RUSTSEC alert for hashbrown [WPB-21413]

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -24,10 +24,6 @@ ignore = [
   # and will be in rsa v0.10, once that comes out of the eternal
   # pre-release state. We need to update it via our rusty-jwt-simple.
   "RUSTSEC-2023-0071",
-
-  # This is fixed in hashbrown >= 0.15.1, however we depend on it indirectly,
-  # via testcontainers, keycloak -> reqwest...
-  "RUSTSEC-2024-0402",
 ]
 
 [licenses]


### PR DESCRIPTION
We use two different versions of that crate, both of them dating from after it was fixed.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
